### PR TITLE
add read command to read from credentials file

### DIFF
--- a/bmx/bmxprint.py
+++ b/bmx/bmxprint.py
@@ -36,7 +36,8 @@ def create_parser():
 
     parser.add_argument(
         '--profile',
-        help='reads an existing profile from the credentials file'
+        help='reads an existing profile from the credentials file',
+        default=''
     )
 
     return parser

--- a/tests/test_bmxprint.py
+++ b/tests/test_bmxprint.py
@@ -91,8 +91,8 @@ export AWS_SESSION_TOKEN='{}'
             self.assertEqual(0, bmx.bmxprint.cmd([]))
         printed = out.getvalue()
 
-        self.assertEqual("""$env:AWS_ACCESS_KEY_ID = '{}'
-$env:AWS_SECRET_ACCESS_KEY = '{}'
+        self.assertEqual("""$env:AWS_ACCESS_KEY_ID = '{}';
+$env:AWS_SECRET_ACCESS_KEY = '{}';
 $env:AWS_SESSION_TOKEN = '{}'
 """.format(
     ACCESS_KEY_ID,
@@ -115,6 +115,7 @@ $env:AWS_SESSION_TOKEN = '{}'
         mock.j = json
         mock.b = bash
         mock.p = powershell
+        mock.profile = ''
 
         return mock
 


### PR DESCRIPTION
This will read from ~/.aws/credentials and dump the data to the appropriate environment variables. Initial implementation supports powershell and you can pipe the output directly to `Invoke-Expression` to set the env vars for you.