### PR TITLE
Remove support for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-- '3.5'
 - '3.6'
 
 install:


### PR DESCRIPTION
* I have heard that we are okay with deprecating 3.5 to take full advantage of the offerings in 3.6