### PR TITLE
Force prompt if account/role not found

### DIFF
--- a/bmx/prompt.py
+++ b/bmx/prompt.py
@@ -7,8 +7,8 @@ class MinMenu:
         self.prompt = prompt
         self.read_function = read_function
 
-    def get_selection(self):
-        if len(self.items) > 1:
+    def get_selection(self, force_prompt=False):
+        if len(self.items) > 1 or force_prompt:
             index = self.prompt_for_choice()
         else:
             index = 0

--- a/bmx/stsutil.py
+++ b/bmx/stsutil.py
@@ -60,7 +60,7 @@ def get_app_selection(applinks, app=None):
             '\nAvailable AWS Accounts: ',
             list(map(lambda x: '{}'.format(x.label), applinks)),
             'AWS Account Index: '
-        ).get_selection()
+        ).get_selection(force_prompt=app)
     ]
 
 def get_role_selection(app_name, roles, role=None):
@@ -75,7 +75,7 @@ def get_role_selection(app_name, roles, role=None):
             '\nAvailable Roles in {}:'.format(app_name),
             list(map(lambda x: re.sub('.*role/', '', x.split(',')[1]), roles)),
             'Role Index: '
-        ).get_selection()
+        ).get_selection(force_prompt=role)
     ]
 
 def get_app_roles(saml_assertion):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -47,6 +47,13 @@ class PromptTests(unittest.TestCase):
 
         self.assertEqual(1, menu.get_selection())
 
+    def test_get_selection_should_prompt_when_forced(self):
+        items = ['foo']
+        menu = bmx.prompt.MinMenu(TITLE, items, PROMPT)
+        menu.prompt_for_choice = Mock(return_value=1)
+
+        self.assertEqual(1, menu.get_selection(force_prompt=True))
+
     def test_prompt_for_choice_should_prompt_for_index_always(self):
         return_value = 2
         read_function = Mock(return_value = return_value);


### PR DESCRIPTION
Forces the selection prompt if the account or role specified is not available, even if there is only one available account/role. Previously, the only available account/role would be used by default, with no indication that the requested account/role was invalid.

Eg.
```
$  bmx print --role fake
...
Available Roles in Dev-CI:
 1: AWS-CI-USER
Role Index:
```