### PR TITLE
Print aws credential keys

### DIFF
--- a/bmx/bmxprint.py
+++ b/bmx/bmxprint.py
@@ -93,6 +93,7 @@ def cmd(args):
     )
 
     print(format_credentials(known_args, credentials))
+    credentialsutil.write_credentials(credentials)
 
     return 0
 

--- a/tests/test_bmxprint.py
+++ b/tests/test_bmxprint.py
@@ -109,16 +109,22 @@ $env:AWS_SESSION_TOKEN = '{}'
 
     @patch('builtins.print')
     @patch('bmx.bmxprint.format_credentials')
+    @patch('bmx.credentialsutil.write_credentials')
     @patch('bmx.credentialsutil.fetch_credentials')
-    def test_cmd_with_account_and_role_should_pass_correct_args_to_awscli(self, mock_fetch_credentials, *mocks):
+    def test_cmd_with_account_and_role_should_pass_correct_args_to_awscli(self,
+                                                                          mock_fetch_credentials,
+                                                                          mock_write_credentials,
+                                                                          *mocks):
         username, duration, account, role = 'my-user', '123', 'my-account', 'my-role'
         known_args = ['--username', username,
                       '--duration', duration,
                       '--account', account,
                       '--role', role]
+        mock_fetch_credentials.return_value = RETURN_VALUE
 
         bmx.bmxprint.cmd(known_args)
         mock_fetch_credentials.assert_called_with(username=username, duration_seconds=duration, app=account, role=role)
+        mock_write_credentials.assert_called_with(RETURN_VALUE)
 
     def setup_print_mocks(self, mock_parser, json, bash, powershell, mock_fetch_credentials=None):
         mock_parser.return_value.parse_known_args.return_value = \


### PR DESCRIPTION
* Remove `--profile` support from `print` command (~/.bmx/credentials doesn't support profiles)
* Ability to print keys from AwsCredentials implementation

## Open Item
Should print cache keys in ~/.bmx/credentials?

## Next If Needed (different PR)
* Make print tests E2E