### PR TITLE
Remove side-effects from test_bmxaws

### DIFF
--- a/tests/test_bmxaws.py
+++ b/tests/test_bmxaws.py
@@ -30,9 +30,15 @@ class BmxAwsTests(unittest.TestCase):
         self.assertEqual('--role', calls[2][0][0])
         self.assertTrue('help' in calls[2][1])
 
+    @patch('bmx.credentialsutil.fetch_credentials')
+    @patch('bmx.credentialsutil.write_credentials')
     @patch('bmx.bmxaws.create_parser')
     @patch('awscli.clidriver.create_clidriver')
-    def test_cmd_should_delegate_to_aws_always(self, mock_clidriver, mock_arg_parser):
+    def test_cmd_should_delegate_to_aws_always(self,
+                                               mock_clidriver,
+                                               mock_arg_parser,
+                                               mock_write_credentials,
+                                               mock_fetch_credentials):
         ARGS = ['arg']
         KNOWN_ARGS = Mock(
             **{
@@ -44,31 +50,41 @@ class BmxAwsTests(unittest.TestCase):
         UNKNOWN_ARGS = 'unknown args'
 
         mock_arg_parser.return_value.parse_known_args.return_value = [KNOWN_ARGS,UNKNOWN_ARGS]
-        credentialsutil.fetch_credentials = Mock(return_value = AwsCredentials({
+        mock_fetch_credentials.return_value =  AwsCredentials({
             'AccessKeyId': 'access key id',
             'SecretAccessKey': 'secret access key',
             'SessionToken': 'session token'
-        }, '', ''))
+        }, '', '')
         mock_clidriver.return_value.main.return_value = 0
-        credentialsutil.write_credentials = Mock()
+        mock_write_credentials.return_value = Mock()
 
         self.assertEqual(0, bmxaws.cmd(ARGS))
 
         mock_arg_parser.return_value.parse_known_args.assert_called_with(ARGS)
         mock_clidriver.return_value.main.assert_called_with(UNKNOWN_ARGS)
 
+    @patch('bmx.credentialsutil.fetch_credentials')
+    @patch('bmx.credentialsutil.write_credentials')
     @patch('awscli.clidriver')
-    def test_cmd_with_account_and_role_should_pass_correct_args_to_awscli(self, mock_awscli):
+    def test_cmd_with_account_and_role_should_pass_correct_args_to_awscli(self,
+                                                                          mock_awscli,
+                                                                          mock_write_credentials,
+                                                                          mock_fetch_credentials):
         known_args = ['--account', 'my-account',
                       '--username', 'my-user',
                       '--role', 'my-role']
         unknown_args = ['aws_command', 'sub_command']
 
-        credentialsutil.write_credentials = Mock()
+        mock_fetch_credentials.return_value = AwsCredentials({
+            'AccessKeyId': 'access key id',
+            'SecretAccessKey': 'secret access key',
+            'SessionToken': 'session token'
+        }, '', '')
+        mock_write_credentials.return_value = Mock()
 
         bmxaws.cmd(known_args + unknown_args)
 
         mock_awscli.create_clidriver.return_value.main.assert_called_with(unknown_args)
 
 if __name__ == '__main__':
-    unittest.main();
+    unittest.main()


### PR DESCRIPTION
Previously `credentialsutil` was being modified causing side-effects from tests that might have wanted to use unmocked version of `fetch_credentials` or `write_credentials`. Now instead of modifying `credentialsutil` just mock out the methods for the duration of the test.