### PR TITLE
Bmx Test Prompt

### DIFF
--- a/bmx/prompt.py
+++ b/bmx/prompt.py
@@ -2,6 +2,8 @@
 
 class MinMenu:
     def __init__(self, title, items, prompt, read_function=input):
+        if not items or len(items) < 1:
+            raise ValueError("At least one item required.")
         self.title = title
         self.items = items
         self.prompt = prompt

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -21,14 +21,16 @@ class PromptTests(unittest.TestCase):
             VALUE,
             prompt.prompt_for_value(read_function, PROMPT))
 
+    def test_invalid_minmenu(self):
+        with self.assertRaises(ValueError):
+            prompt.MinMenu(TITLE, [], PROMPT)
+
     @patch('bmx.prompt.MinMenu.prompt_for_choice')
     def test_get_selection_should_return_0_when_items_is_empty_or_single(self, mock_prompt_for_choice):
-        for i in [[], ['foo']]:
-            with self.subTest(i=i):
-                menu = prompt.MinMenu(TITLE, i, PROMPT)
+            menu = prompt.MinMenu(TITLE, ['foo'], PROMPT)
 
-                self.assertEqual(0, menu.get_selection())
-                mock_prompt_for_choice.assert_not_called()
+            self.assertEqual(0, menu.get_selection())
+            mock_prompt_for_choice.assert_not_called()
 
     @patch('bmx.prompt.MinMenu.prompt_for_choice')
     def test_get_selection_should_prompt_when_items_has_multiple(self, mock_prompt_for_choice):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bmx
+envlist = py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
### Question:
I would like to raise an error in `MinMenu` if initialized with an empty set of `items`. If initialized with `[]` the `prompt_for_choice` will trap the user in an infinite prompt loop if `get_selection` is called with `force_prompt=True`. Does this seem reasonable? Or is there some case I don't know about where having an empty list of `items` is valid and `get_selection` should always return 0 in this case (regardless of `force_prompt`)?