### PR TITLE
fix(print) Linux output default should be bash exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ build
 .coverage
 .*.swp
 .idea/
-bmx.exe
+cmd/bmx/bmx.exe
+cmd/bmx/bmx

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -94,6 +94,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "69529dd065df0718e28242ed6c5cb75238b811f83c59f27a71f4e0c013ab3882"
+  inputs-digest = "27617a83db771f8b6a0a2b843e8b37b3f211dda52dd33a210ff1396d22455031"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/password/password_linux.go
+++ b/password/password_linux.go
@@ -21,5 +21,5 @@ func read(f *os.File) (string, error) {
 	}
 	defer terminal.Restore(fd, oldState)
 
-	return readLine()
+	return readLine(f)
 }

--- a/password/password_windows.go
+++ b/password/password_windows.go
@@ -36,7 +36,7 @@ func read(f *os.File) (string, error) {
 		return "", err
 	}
 
-	return readLine()
+	return readLine(f)
 }
 
 func setConsoleMode(console syscall.Handle, mode uint32) error {

--- a/print.go
+++ b/print.go
@@ -103,6 +103,7 @@ func Print(config Options, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+		fmt.Fprintln(os.Stderr)
 	}
 
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"
@@ -310,5 +311,9 @@ type Saml2Attribute struct {
 }
 
 func printPowershell(credentials *sts.Credentials) {
-	fmt.Printf(`$env:AWS_SESSION_TOKEN="%s"; $env:AWS_ACCESS_KEY_ID="%s"; $env:AWS_SECRET_ACCESS_KEY="%s"`, *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
+	fmt.Printf(`$env:AWS_SESSION_TOKEN='%s'; $env:AWS_ACCESS_KEY_ID='%s'; $env:AWS_SECRET_ACCESS_KEY='%s'`, *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
+}
+
+func printBash(credentials *sts.Credentials) {
+	fmt.Printf("export AWS_SESSION_TOKEN=%s\nexport AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s", *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
 }

--- a/print_linux.go
+++ b/print_linux.go
@@ -5,5 +5,5 @@ import (
 )
 
 func printDefaultFormat(credentials *sts.Credentials) {
-	printPowershell(credentials)
+	printBash(credentials)
 }


### PR DESCRIPTION
Fixes password input on Linux and sets the output correctly to bash exports.

Verified manually on Windows and Linux.