### PR TITLE
fix: separate Windows and Linux input read paths

### DIFF
--- a/password/password.go
+++ b/password/password.go
@@ -6,9 +6,9 @@
 package password
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 )
 
@@ -16,30 +16,16 @@ var ErrInterrupted = errors.New("interrupted")
 
 func Read(prompt string) (string, error) {
 	fmt.Fprint(os.Stderr, prompt)
-	return read(os.Stdin)
+	return read()
 }
 
-func readLine(f *os.File) (string, error) {
-	var buf [1]byte
-	resultBuf := make([]byte, 0, 64)
-	for {
-		n, err := f.Read(buf[:])
-		if err != nil && err != io.EOF {
-			return "", err
-		}
-		if n == 0 || buf[0] == '\n' || buf[0] == '\r' {
-			break
-		}
-
-		// ASCII code 3 is what is sent for a Ctrl-C while reading raw.
-		// If we see that, then get the interrupt. We have to do this here
-		// because terminals in raw mode won't catch it at the shell level.
-		if buf[0] == 3 {
-			return "", ErrInterrupted
-		}
-
-		resultBuf = append(resultBuf, buf[0])
+func readLine() (string, error) {
+	scanner := bufio.NewScanner(os.Stdin)
+	var s string
+	scanner.Scan()
+	if scanner.Err() != nil {
+		return "", scanner.Err()
 	}
-
-	return string(resultBuf), nil
+	s = scanner.Text()
+	return s, nil
 }

--- a/password/password_linux.go
+++ b/password/password_linux.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func read(f *os.File) (string, error) {
-	fd := int(f.Fd())
+func read() (string, error) {
+	fd := int(os.Stdin.Fd())
 	if !terminal.IsTerminal(fd) {
 		return "", fmt.Errorf("file descriptor %d is not a terminal", fd)
 	}
@@ -21,5 +21,5 @@ func read(f *os.File) (string, error) {
 	}
 	defer terminal.Restore(fd, oldState)
 
-	return readLine(f)
+	return readLine()
 }

--- a/password/password_windows.go
+++ b/password/password_windows.go
@@ -19,8 +19,8 @@ var (
 // http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
 const ENABLE_ECHO_INPUT = 0x0004
 
-func read(f *os.File) (string, error) {
-	handle := syscall.Handle(f.Fd())
+func read() (string, error) {
+	handle := syscall.Handle(os.Stdin.Fd())
 
 	// Grab the old console mode so we can reset it. We defer the reset
 	// right away because it doesn't matter (it is idempotent).
@@ -36,7 +36,7 @@ func read(f *os.File) (string, error) {
 		return "", err
 	}
 
-	return readLine(f)
+	return readLine()
 }
 
 func setConsoleMode(console syscall.Handle, mode uint32) error {


### PR DESCRIPTION
Why can't we all just use the same line endings?