### PR TITLE
Updating dockerfile to use python 3.6 for bmx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 RUN useradd -ms /bin/bash bmx
 


### PR DESCRIPTION
After talking with Chris Redekop, we found that BMX supports only up to python 3.6. Previously, the code was pulling the latest version of python (3.7 at the current date), and thus was unable to properly resolve dependencies. 