### PR TITLE
drain stdin after reading a password

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,6 +40,14 @@
   version = "v1.15.74"
 
 [[projects]]
+  digest = "1:2f20453442c3bea9708b8f3836cd12cadd31b7397e6cf08197afc2b470faa689"
+  name = "github.com/hashicorp/vault"
+  packages = ["helper/password"]
+  pruneopts = "UT"
+  revision = "a59ffa4a0f09bbf198241fe6793a96722789b639"
+  version = "v0.11.5"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
@@ -157,10 +165,10 @@
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/aws/aws-sdk-go/service/sts/stsiface",
+    "github.com/hashicorp/vault/helper/password",
     "github.com/magiconair/properties/assert",
     "github.com/mitchellh/go-homedir",
     "github.com/spf13/cobra",
-    "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/html",
     "golang.org/x/net/publicsuffix",
     "gopkg.in/ini.v1",

--- a/password/password.go
+++ b/password/password.go
@@ -6,26 +6,22 @@
 package password
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
+
+	pwd "github.com/hashicorp/vault/helper/password"
 )
 
 var ErrInterrupted = errors.New("interrupted")
 
 func Read(prompt string) (string, error) {
 	fmt.Fprint(os.Stderr, prompt)
-	return read()
-}
+	result, err := pwd.Read(os.Stdin)
 
-func readLine() (string, error) {
-	scanner := bufio.NewScanner(os.Stdin)
-	var s string
-	scanner.Scan()
-	if scanner.Err() != nil {
-		return "", scanner.Err()
-	}
-	s = scanner.Text()
-	return s, nil
+	// This discards up to 100 excess bytes on stdin in case we get extra garbage returned after eol has been detected as is the case on Windows with the \r\n pattern
+	var buf [100]byte
+	os.Stdin.Read(buf[:])
+
+	return result, err
 }

--- a/print_unix.go
+++ b/print_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin freebsd netbsd openbsd
+
 package bmx
 
 import (

--- a/vendor/github.com/hashicorp/vault/LICENSE
+++ b/vendor/github.com/hashicorp/vault/LICENSE
@@ -1,0 +1,363 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/vault/helper/password/password.go
+++ b/vendor/github.com/hashicorp/vault/helper/password/password.go
@@ -1,0 +1,64 @@
+// password is a package for reading a password securely from a terminal.
+// The code in this package disables echo in the terminal so that the
+// password is not echoed back in plaintext to the user.
+package password
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+)
+
+var ErrInterrupted = errors.New("interrupted")
+
+// Read reads the password from the given os.File. The password
+// will not be echoed back to the user. Ctrl-C will automatically return
+// from this function with a blank string and an ErrInterrupted.
+func Read(f *os.File) (string, error) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	defer signal.Stop(ch)
+
+	// Run the actual read in a go-routine so that we can still detect signals
+	var result string
+	var resultErr error
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		result, resultErr = read(f)
+	}()
+
+	// Wait on either the read to finish or the signal to come through
+	select {
+	case <-ch:
+		return "", ErrInterrupted
+	case <-doneCh:
+		return result, resultErr
+	}
+}
+
+func readline(f *os.File) (string, error) {
+	var buf [1]byte
+	resultBuf := make([]byte, 0, 64)
+	for {
+		n, err := f.Read(buf[:])
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		if n == 0 || buf[0] == '\n' || buf[0] == '\r' {
+			break
+		}
+
+		// ASCII code 3 is what is sent for a Ctrl-C while reading raw.
+		// If we see that, then get the interrupt. We have to do this here
+		// because terminals in raw mode won't catch it at the shell level.
+		if buf[0] == 3 {
+			return "", ErrInterrupted
+		}
+
+		resultBuf = append(resultBuf, buf[0])
+	}
+
+	return string(resultBuf), nil
+}

--- a/vendor/github.com/hashicorp/vault/helper/password/password_solaris.go
+++ b/vendor/github.com/hashicorp/vault/helper/password/password_solaris.go
@@ -1,0 +1,55 @@
+// +build solaris
+
+package password
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func read(f *os.File) (string, error) {
+	fd := int(f.Fd())
+	if !isTerminal(fd) {
+		return "", fmt.Errorf("file descriptor %d is not a terminal", fd)
+	}
+
+	oldState, err := makeRaw(fd)
+	if err != nil {
+		return "", err
+	}
+	defer unix.IoctlSetTermios(fd, unix.TCSETS, oldState)
+
+	return readline(f)
+}
+
+// isTerminal returns true if there is a terminal attached to the given
+// file descriptor.
+// Source: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func isTerminal(fd int) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(fd, unix.TCGETA, &termio)
+	return err == nil
+}
+
+// makeRaw puts the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+// Source: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libast/common/uwin/getpass.c
+func makeRaw(fd int) (*unix.Termios, error) {
+	oldTermiosPtr, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	oldTermios := *oldTermiosPtr
+
+	newTermios := oldTermios
+	newTermios.Lflag &^= syscall.ECHO | syscall.ECHOE | syscall.ECHOK | syscall.ECHONL
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &newTermios); err != nil {
+		return nil, err
+	}
+
+	return oldTermiosPtr, nil
+}

--- a/vendor/github.com/hashicorp/vault/helper/password/password_unix.go
+++ b/vendor/github.com/hashicorp/vault/helper/password/password_unix.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func read() (string, error) {
-	fd := int(os.Stdin.Fd())
+func read(f *os.File) (string, error) {
+	fd := int(f.Fd())
 	if !terminal.IsTerminal(fd) {
 		return "", fmt.Errorf("file descriptor %d is not a terminal", fd)
 	}
@@ -21,5 +21,5 @@ func read() (string, error) {
 	}
 	defer terminal.Restore(fd, oldState)
 
-	return readLine()
+	return readline(f)
 }

--- a/vendor/github.com/hashicorp/vault/helper/password/password_windows.go
+++ b/vendor/github.com/hashicorp/vault/helper/password/password_windows.go
@@ -3,7 +3,6 @@
 package password
 
 import (
-	"log"
 	"os"
 	"syscall"
 )
@@ -19,24 +18,24 @@ var (
 // http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
 const ENABLE_ECHO_INPUT = 0x0004
 
-func read() (string, error) {
-	handle := syscall.Handle(os.Stdin.Fd())
+func read(f *os.File) (string, error) {
+	handle := syscall.Handle(f.Fd())
 
 	// Grab the old console mode so we can reset it. We defer the reset
 	// right away because it doesn't matter (it is idempotent).
 	var oldMode uint32
 	if err := syscall.GetConsoleMode(handle, &oldMode); err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	defer setConsoleMode(handle, oldMode)
 
-	//The new mode is the old mode WITHOUT the echo input flag set.
+	// The new mode is the old mode WITHOUT the echo input flag set.
 	var newMode uint32 = uint32(int(oldMode) & ^ENABLE_ECHO_INPUT)
 	if err := setConsoleMode(handle, newMode); err != nil {
 		return "", err
 	}
 
-	return readLine()
+	return readline(f)
 }
 
 func setConsoleMode(console syscall.Handle, mode uint32) error {

--- a/vendor/github.com/hashicorp/vault/ui/app/adapters/license.js
+++ b/vendor/github.com/hashicorp/vault/ui/app/adapters/license.js
@@ -1,0 +1,36 @@
+import ClusterAdapter from './cluster';
+
+export default ClusterAdapter.extend({
+  queryRecord() {
+    return this._super(...arguments).then(resp => {
+      resp.data.id = resp.data.license_id;
+      return resp.data;
+    });
+  },
+
+  createRecord(store, type, snapshot) {
+    let id = snapshot.attr('licenseId');
+    return this._super(...arguments).then(() => {
+      return {
+        id,
+      };
+    });
+  },
+
+  updateRecord(store, type, snapshot) {
+    let id = snapshot.attr('licenseId');
+    return this._super(...arguments).then(() => {
+      return {
+        id,
+      };
+    });
+  },
+
+  pathForType() {
+    return 'license';
+  },
+
+  urlForUpdateRecord() {
+    return this.buildURL() + '/license';
+  },
+});

--- a/vendor/github.com/hashicorp/vault/ui/app/components/license-info.js
+++ b/vendor/github.com/hashicorp/vault/ui/app/components/license-info.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+import { allFeatures } from 'vault/helpers/all-features';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  expirationTime: '',
+  startTime: '',
+  licenseId: '',
+  features: null,
+  text: '',
+  showForm: false,
+  isTemporary: computed('licenseId', function() {
+    return this.licenseId === 'temporary';
+  }),
+  featuresInfo: computed('features', function() {
+    let info = [];
+    allFeatures().forEach(feature => {
+      let active = this.features.includes(feature) ? true : false;
+      info.push({ name: feature, active: active });
+    });
+    return info;
+  }),
+  saveModel() {},
+  actions: {
+    saveModel(text) {
+      this.saveModel(text);
+    },
+    toggleForm() {
+      this.toggleProperty('showForm');
+    },
+  },
+});

--- a/vendor/github.com/hashicorp/vault/ui/app/controllers/vault/cluster/license.js
+++ b/vendor/github.com/hashicorp/vault/ui/app/controllers/vault/cluster/license.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  licenseSuccess() {
+    this.send('doRefresh');
+  },
+  licenseError() {
+    //eat the error (handled in MessageError component)
+  },
+  actions: {
+    saveModel({ text }) {
+      this.model.save({ text }).then(() => this.licenseSuccess(), () => this.licenseError());
+    },
+  },
+});

--- a/vendor/github.com/hashicorp/vault/ui/app/models/license.js
+++ b/vendor/github.com/hashicorp/vault/ui/app/models/license.js
@@ -1,0 +1,29 @@
+import DS from 'ember-data';
+const { attr } = DS;
+
+/* sample response
+{
+  "data": {
+    "expiration_time": "2017-11-14T16:34:36.546753-05:00",
+    "features": [
+      "UI",
+      "HSM",
+      "Performance Replication",
+      "DR Replication"
+    ],
+    "license_id": "temporary",
+    "start_time": "2017-11-14T16:04:36.546753-05:00"
+  },
+  "warnings": [
+    "time left on license is 29m33s"
+  ]
+}
+*/
+
+export default DS.Model.extend({
+  expirationTime: attr('string'),
+  features: attr('array'),
+  licenseId: attr('string'),
+  startTime: attr('string'),
+  text: attr('string'),
+});

--- a/vendor/github.com/hashicorp/vault/ui/app/routes/vault/cluster/license.js
+++ b/vendor/github.com/hashicorp/vault/ui/app/routes/vault/cluster/license.js
@@ -1,0 +1,22 @@
+import Route from '@ember/routing/route';
+import ClusterRoute from 'vault/mixins/cluster-route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend(ClusterRoute, {
+  version: service(),
+  beforeModel() {
+    if (this.version.isOSS) {
+      this.transitionTo('vault.cluster');
+    }
+  },
+
+  model() {
+    return this.store.queryRecord('license', {});
+  },
+
+  actions: {
+    doRefresh() {
+      this.refresh();
+    },
+  },
+});

--- a/vendor/github.com/hashicorp/vault/ui/app/templates/components/license-info.hbs
+++ b/vendor/github.com/hashicorp/vault/ui/app/templates/components/license-info.hbs
@@ -1,0 +1,77 @@
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">License</h1>
+  </p.levelLeft>
+</PageHeader>
+<MessageError @model={{model}} />
+{{#if isTemporary}}
+  <section class="box is-sideless">
+    <MessageInPage data-test-cluster-status @type="warning" @class="license-warning" data-test-warning-text>
+      Your temporary license expires {{moment-from-now expirationTime}} and your vault will seal. Please enter a valid license below.
+    </MessageInPage>
+    <span class="title is-5" data-test-temp-license>Temporary License</span>
+    <form {{action "saveModel" text on="submit"}}>
+      <div class="box is-shadowless is-fullwidth is-marginless">
+        <div class="field">
+          <label for="license-id" class="is-label">License</label>
+          <div class="control">
+            {{input id="license-id" value=text autocomplete="off" class="input" data-test-text-input="data-test-text-input"}}
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <div class="control">
+          <button type="submit" class="button is-primary" data-test-save-button>Save</button>
+        </div>
+      </div>
+    </form>
+  </section>
+{{else}}
+  <section class="box is-sideless">
+    <span class="title is-5">Details</span>
+    {{#if showForm}}
+      <form {{action "saveModel" text on="submit"}}>
+        <div class="field">
+          <label for="license-id" class="is-label">License</label>
+          <div class="control">
+            {{input id="license-id" value=text autocomplete="off" class="input" data-test-text-input="data-test-text-input"}}
+          </div>
+        </div>
+        <div class="field is-grouped">
+          <div class="control">
+            <button type="submit" class="button is-primary" data-test-save-button>Save</button>
+          </div>
+          <div class="control">
+            <button type="button" {{action "toggleForm"}} class="button" data-test-cancel-button>Cancel</button>
+          </div>
+        </div>
+      </form>
+    {{else}}
+      <div class="field box is-fullwidth is-shadowless is-paddingless is-marginless">
+        {{info-table-row label="License ID" value=licenseId}}
+        {{#info-table-row label="Valid from" value=startTime}}
+          {{moment-format model.startTime 'MMM DD, YYYY hh:mm:ss A'}} to {{moment-format expirationTime 'MMM DD, YYYY hh:mm:ss A'}}
+        {{/info-table-row}}
+      </div>
+      <div class="field box is-fullwidth is-shadowless is-paddingless is-marginless">
+        <div class="control">
+          <button type="button" {{action "toggleForm"}} class="button" data-test-enter-button>Enter new license</button>
+        </div>
+      </div>
+    {{/if}}
+    </section>
+  {{/if}}
+<section class="box is-sideless is-marginless is-shadowless">
+  <span class="title is-5">Features</span>
+  <div class="field box is-fullwidth is-shadowless is-paddingless is-marginless">
+    {{#each featuresInfo as |info|}}
+      {{#info-table-row label=info.name value=(if info.active "Active" "Not Active") data-test-feature-row="data-test-feature-row"}}
+        {{#if info.active}}
+          <ICon @size=28 @glyph="true" /> <span data-test-feature-status>Active</span>
+        {{else}}
+          <ICon @size=28 @glyph="false" /> <span data-test-feature-status>Not Active</span>
+        {{/if}}
+      {{/info-table-row}}
+    {{/each}}
+  </div>
+</section>

--- a/vendor/github.com/hashicorp/vault/ui/app/templates/vault/cluster/license.hbs
+++ b/vendor/github.com/hashicorp/vault/ui/app/templates/vault/cluster/license.hbs
@@ -1,0 +1,9 @@
+<LicenseInfo
+  @startTime={{model.startTime}}
+  @expirationTime={{model.expirationTime}}
+  @licenseId={{model.licenseId}}
+  @features={{model.features}}
+  @text={{model.text}}
+  @saveModel={{action "saveModel"}}
+  @model={{model}}
+/>

--- a/vendor/github.com/hashicorp/vault/ui/tests/integration/components/license-test.js
+++ b/vendor/github.com/hashicorp/vault/ui/tests/integration/components/license-test.js
@@ -1,0 +1,109 @@
+import moment from 'moment';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import { create } from 'ember-cli-page-object';
+import license from '../../pages/components/license-info';
+
+const component = create(license);
+
+module('Integration | Component | license info', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    component.setContext(this);
+  });
+
+  hooks.afterEach(function() {
+    component.removeContext();
+  });
+
+  const LICENSE_WARNING_TEXT = `Warning Your temporary license expires in 30 minutes and your vault will seal. Please enter a valid license below.`;
+
+  test('it renders properly for temporary license', async function(assert) {
+    this.set('licenseId', 'temporary');
+    this.set('expirationTime', moment(moment.now()).add(30, 'minutes'));
+    this.set('startTime', moment.now());
+    this.set('features', ['HSM', 'Namespaces']);
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}}/>`
+    );
+    assert.equal(component.warning, LICENSE_WARNING_TEXT, 'it renders warning text including time left');
+    assert.equal(component.hasSaveButton, true, 'it renders the save button');
+    assert.equal(component.hasTextInput, true, 'it renders text input for new license');
+    assert.equal(component.featureRows.length, 12, 'it renders 12 features');
+    assert.equal(component.featureRows[0].featureName, 'HSM', 'it renders HSM feature');
+    assert.equal(component.featureRows[0].featureStatus, 'Active', 'it renders Active for HSM feature');
+    assert.equal(
+      component.featureRows[1].featureName,
+      'Performance Replication',
+      'it renders Performance Replication feature name'
+    );
+    assert.equal(
+      component.featureRows[1].featureStatus,
+      'Not Active',
+      'it renders Not Active for Performance Replication'
+    );
+  });
+
+  test('it renders feature status properly for features associated with license', async function(assert) {
+    this.set('licenseId', 'temporary');
+    this.set('expirationTime', moment(moment.now()).add(30, 'minutes'));
+    this.set('startTime', moment.now());
+    this.set('features', ['HSM', 'Namespaces']);
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}}/>`
+    );
+    assert.equal(component.featureRows.length, 12, 'it renders 12 features');
+    let activeFeatures = component.featureRows.filter(f => f.featureStatus === 'Active');
+    assert.equal(activeFeatures.length, 2);
+  });
+
+  test('it renders properly for non-temporary license', async function(assert) {
+    this.set('licenseId', 'test');
+    this.set('expirationTime', moment(moment.now()).add(30, 'minutes'));
+    this.set('startTime', moment.now());
+    this.set('features', ['HSM', 'Namespaces']);
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}}/>`
+    );
+    assert.equal(component.hasWarning, false, 'it does not have a warning');
+    assert.equal(component.hasSaveButton, false, 'it does not render the save button');
+    assert.equal(component.hasTextInput, false, 'it does not render the text input for new license');
+    assert.equal(component.hasEnterButton, true, 'it renders the button to toggle license form');
+  });
+
+  test('it shows and hides license form when enter and cancel buttons are clicked', async function(assert) {
+    this.set('licenseId', 'test');
+    this.set('expirationTime', moment(moment.now()).add(30, 'minutes'));
+    this.set('startTime', moment.now());
+    this.set('features', ['HSM', 'Namespaces']);
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}}/>`
+    );
+    await component.enterButton();
+    assert.equal(component.hasSaveButton, true, 'it does not render the save button');
+    assert.equal(component.hasTextInput, true, 'it does not render the text input for new license');
+    assert.equal(component.hasEnterButton, false, 'it renders the button to toggle license form');
+    await component.cancelButton();
+    assert.equal(component.hasSaveButton, false, 'it does not render the save button');
+    assert.equal(component.hasTextInput, false, 'it does not render the text input for new license');
+    assert.equal(component.hasEnterButton, true, 'it renders the button to toggle license form');
+  });
+
+  test('it calls saveModel when save button is clicked', async function(assert) {
+    this.set('licenseId', 'temporary');
+    this.set('expirationTime', moment(moment.now()).add(30, 'minutes'));
+    this.set('startTime', moment.now());
+    this.set('features', ['HSM', 'Namespaces']);
+    this.set('saveModel', sinon.spy());
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}} @saveModel={{this.saveModel}}/>`
+    );
+    await component.text('ABCDE12345');
+    await component.saveButton();
+    assert.ok(this.get('saveModel').calledOnce);
+  });
+});

--- a/vendor/github.com/hashicorp/vault/ui/tests/pages/components/license-info.js
+++ b/vendor/github.com/hashicorp/vault/ui/tests/pages/components/license-info.js
@@ -1,0 +1,18 @@
+import { clickable, fillable, text, isPresent, collection } from 'ember-cli-page-object';
+
+export default {
+  text: fillable('[data-test-text-input]'),
+  isTemp: isPresent('[data-test-temp-license]'),
+  hasTextInput: isPresent('[data-test-text-input]'),
+  saveButton: clickable('[data-test-save-button]'),
+  hasSaveButton: isPresent('[data-test-save-button]'),
+  enterButton: clickable('[data-test-enter-button]'),
+  hasEnterButton: isPresent('[data-test-enter-button]'),
+  cancelButton: clickable('[data-test-cancel-button]'),
+  hasWarning: isPresent('[data-test-warning-text]'),
+  warning: text('[data-test-warning-text]'),
+  featureRows: collection('[data-test-feature-row]', {
+    featureName: text('[data-test-row-label]'),
+    featureStatus: text('[data-test-feature-status]'),
+  }),
+};

--- a/vendor/github.com/hashicorp/vault/website/LICENSE.md
+++ b/vendor/github.com/hashicorp/vault/website/LICENSE.md
@@ -1,0 +1,10 @@
+# Proprietary License
+
+This license is temporary while a more official one is drafted. However,
+this should make it clear:
+
+The text contents of this website are MPL 2.0 licensed.
+
+The design contents of this website are proprietary and may not be reproduced
+or reused in any way other than to run the website locally. The license for
+the design is owned solely by HashiCorp, Inc.

--- a/vendor/github.com/hashicorp/vault/website/source/api/system/license.html.md
+++ b/vendor/github.com/hashicorp/vault/website/source/api/system/license.html.md
@@ -1,0 +1,88 @@
+---
+layout: "api"
+page_title: "/sys/license - HTTP API"
+sidebar_title: "<tt>/sys/license</tt>"
+sidebar_current: "api-http-system-license"
+description: |-
+  The `/sys/license` endpoint is used to view and update the license used in 
+  Vault.
+---
+
+# `/sys/license`
+
+~> **Enterprise Only** – These endpoints require Vault Enterprise.
+
+The `/sys/license` endpoint is used to view and update the license used in 
+Vault.
+
+## Read License
+
+This endpoint returns information about the currently installed license.
+
+| Method   | Path                         | Produces               |
+| :------- | :--------------------------- | :--------------------- |
+| `GET`    | `/sys/license`                | `200 application/json` |
+
+### Sample Request
+
+```
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/license
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "expiration_time": "2017-11-14T16:34:36.546753-05:00",
+    "features": [
+      "UI",
+      "HSM",
+      "Performance Replication",
+      "DR Replication"
+    ],
+    "license_id": "temporary",
+    "start_time": "2017-11-14T16:04:36.546753-05:00"
+  },
+  "warnings": [
+    "time left on license is 29m33s"
+  ]
+}
+```
+
+## Install License
+
+This endpoint is used to install a license into Vault.
+
+| Method   | Path                         | Produces               |
+| :------- | :--------------------------- | :--------------------- |
+| `PUT`    | `/sys/license`                | `204 (empty body)` |
+
+### Parameters
+
+- `text` `(string: <required>)` – The text of the license.
+
+*DR Secondary Specific Parameters*
+
+  - `dr_operation_token` `(string: <required>)` - DR operation token used to authorize this request.
+
+
+### Sample Payload
+
+```json
+{
+  "text": "01ABCDEFG..."
+}
+```
+
+### Sample Request
+
+```
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/license
+```


### PR DESCRIPTION
The password reading package leaves a trailing \n on Windows which is breaking a bunch of things. The previous hacky implementation didn't work properly on Mac.
I've changed things over to use the default password package in Vault and added a small trap to drain stdin after reading a password.