### PR TITLE
Allow newer versions of lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ _PACKAGES = ['bmx']
 
 _REQUIRES = [
         'future>=0.16.0',
-        'lxml==4.0.0',
+        'lxml>=4.0.0',
         'okta>=0.0.4',
         'pies2overrides>=2.6.7',
         'prompt>=0.4.1',


### PR DESCRIPTION
When attempting to use BMX for the first time on Windows I installed python 3.7.1 and then ran `py -3 -m pip install --user --upgrade --extra-index-url https://d2lartifacts.artifactoryonline.com/d2lart
ifacts/api/pypi/pypi-local/simple bmx` as indicated in the README. However I encountered an error: `Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?`. I attempted to rectify this by manually installing `lxml`, but it was installed and the error persisted. It seems that I had `lxml-4.2.5` installed but BMX is expecting `4.0.0` exclusively. By modifying the requirement to allow versions `>=4.0.0` I was able to successfully run the setup command, and so I believe this change would be handy for others.