### PR TITLE
Support automated releases using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: GitHub Release
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Validate config
+        uses: docker://goreleaser/goreleaser@sha256:83ea87528d24d5c5cafa92674f79ccdd5fad6d6fbb906d0925e8913e3e3f4248
+        with:
+          args: check
+      - name: Release
+        uses: docker://goreleaser/goreleaser@sha256:83ea87528d24d5c5cafa92674f79ccdd5fad6d6fbb906d0925e8913e3e3f4248
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ changelog:
   skip: true
 release:
   github:
-    owner: Brightspace
+    owner: jrbeverly
     name: bmx
   prerelease: auto
   name_template: "v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ changelog:
   skip: true
 release:
   github:
-    owner: jrbeverly
+    owner: Brightspace
     name: bmx
   prerelease: auto
   name_template: "v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - binary: "{{.ProjectName}}_v{{.Version}}"
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+archives:
+  - format: zip
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  skip: true
+release:
+  github:
+    owner: Brightspace
+    name: bmx
+  prerelease: auto
+  name_template: "v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
   - binary: "{{.ProjectName}}_v{{.Version}}"
+    main: ./cmd/bmx/bmx.go
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,3 @@
-before:
-  hooks:
-    - go mod download
-
 builds:
   - binary: "{{.ProjectName}}_v{{.Version}}"
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ changelog:
   skip: true
 release:
   github:
-    owner: Brightspace
+    owner: jrbeverly
     name: bmx
   prerelease: auto
   name_template: "v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 builds:
   - binary: "{{.ProjectName}}_v{{.Version}}"
-    main: ./cmd/bmx/bmx.go
+    main: ./cmd/bmx/
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0


### PR DESCRIPTION
The release binaries for GitHub are not built as part of the release process. This means they need to be compiled on a developer machine, which isn't ideal. Using GitHub Actions we can automate this process with a single workflow (+ goreleaser).

This PRs adds a workflow to GitHub Actions that will build the binaries when a release is created. This will include a windows and linux release (for amd64), with a checksums file. [GoReleaser](https://goreleaser.com/) handles the compilation and deployment to github.

This was tested with my local fork (jrbeverly/bmx), which works really well for prototyping ideas without needing a TravisCI account.