### PR TITLE
Configure Coveralls in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Vet
         run: go vet ./...
-      - name: Code Coverage Tools
-        run: |
-          go get golang.org/x/tools/cmd/cover
-          go get github.com/mattn/goveralls
       - name: Test
-        run: go test -v -covermode="count" -coverprofile="coverage.out" ./...
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -v -covermode="count" -coverprofile="profile.cov" ./...
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          GO111MODULE=off go get github.com/mattn/goveralls
+          $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Test
         run: go test -v -covermode="count" -coverprofile="profile.cov" ./...
       - name: Send coverage
+        if: matrix.platform == 'ubuntu-latest'
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,21 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Vet
-      run: go vet ./...
-    - name: Test
-      run: go test -v -covermode="count" -coverprofile="coverage.out" ./...
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Vet
+        run: go vet ./...
+      - name: Code Coverage Tools
+        run: |
+          go get golang.org/x/tools/cmd/cover
+          go get github.com/mattn/goveralls
+      - name: Test
+        run: go test -v -covermode="count" -coverprofile="coverage.out" ./...
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds in Coveralls with GitHub Actions, removing the remaining dependency on TravisCI. You'll see it along with the checks for a pull request, with it reporting the code coverage amount.

After this I'll raise a PR that completes the process of deprecating TravisCI. Additionally I ran a format on the yml file, which change the other files.