### PR TITLE
Remove Coveralls from the repository

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-pro

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,3 @@ jobs:
         run: go vet ./...
       - name: Test
         run: go test -v -covermode="count" -coverprofile="profile.cov" ./...
-      - name: Send coverage
-        if: matrix.platform == 'ubuntu-latest'
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          GO111MODULE=off go get github.com/mattn/goveralls
-          $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Coverage Status](https://coveralls.io/repos/github/Brightspace/bmx/badge.svg?branch=master&t=c1nzIP)](https://coveralls.io/github/Brightspace/bmx?branch=master)
-
 # BMX
 BMX grants you API access to your AWS accounts, based on Okta credentials that you already own.  
 It uses your Okta identity to create short-term AWS STS tokens, as an alternative to long-term IAM access keys.


### PR DESCRIPTION
While implementing the GitHub Actions work, I noticed that coveralls seems to fail often. I suspect this is a requirement (or setting) that enforces code coverage of changes. However it is throwing failures even in the case of document / build harness changes.

This PR removes coveralls and all mentions of it from the repository. 

If at a later date we reconfigure this (or have a strategy for this), we can revert this commit to re-implement.