### PR TITLE
Allow specifying the output format from the command line

### DIFF
--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -36,7 +36,7 @@ func init() {
 	printCmd.Flags().StringVar(&printOptions.Account, "account", "", "the account name to auth against")
 	printCmd.Flags().StringVar(&printOptions.Role, "role", "", "the desired role to assume")
 	printCmd.Flags().BoolVar(&printOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
-	printCmd.Flags().StringVar(&printOptions.Output, "output", "", "the output format")
+	printCmd.Flags().StringVar(&printOptions.Output, "output", "", "the output format [bash|powershell]")
 
 	if userConfig.Org == "" {
 		printCmd.MarkFlagRequired("org")

--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"log"
+	"fmt"
 
 	"github.com/Brightspace/bmx/config"
 
@@ -56,7 +57,8 @@ var printCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		bmx.Print(oktaClient, mergedOptions)
+		command := bmx.Print(oktaClient, mergedOptions)
+		fmt.Println(command)
 	},
 }
 

--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -35,6 +35,7 @@ func init() {
 	printCmd.Flags().StringVar(&printOptions.Account, "account", "", "the account name to auth against")
 	printCmd.Flags().StringVar(&printOptions.Role, "role", "", "the desired role to assume")
 	printCmd.Flags().BoolVar(&printOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
+	printCmd.Flags().StringVar(&printOptions.Output, "output", "", "the output format")
 
 	if userConfig.Org == "" {
 		printCmd.MarkFlagRequired("org")

--- a/print.go
+++ b/print.go
@@ -36,7 +36,6 @@ func init() {
 }
 
 const (
-	OsShell    = "default"
 	Bash       = "bash"
 	Powershell = "powershell"
 )

--- a/print.go
+++ b/print.go
@@ -35,8 +35,6 @@ func init() {
 	AwsServiceProvider = aws.NewAwsServiceProvider()
 }
 
-type OutputFormat string
-
 const (
 	OsShell    = "default"
 	Bash       = "bash"
@@ -50,7 +48,7 @@ type PrintCmdOptions struct {
 	NoMask   bool
 	Password string
 	Role     string
-	Output   OutputFormat
+	Output   string
 }
 
 func GetUserInfoFromPrintCmdOptions(printOptions PrintCmdOptions) serviceProviders.UserInfo {

--- a/print.go
+++ b/print.go
@@ -63,7 +63,7 @@ func GetUserInfoFromPrintCmdOptions(printOptions PrintCmdOptions) serviceProvide
 	return user
 }
 
-func Print(idProvider identityProviders.IdentityProvider, printOptions PrintCmdOptions) {
+func Print(idProvider identityProviders.IdentityProvider, printOptions PrintCmdOptions) string {
 	printOptions.User = getUserIfEmpty(printOptions.User)
 	user := GetUserInfoFromPrintCmdOptions(printOptions)
 
@@ -74,7 +74,7 @@ func Print(idProvider identityProviders.IdentityProvider, printOptions PrintCmdO
 
 	creds := AwsServiceProvider.GetCredentials(saml, printOptions.Role)
 	command := printCommand(printOptions, creds)
-	fmt.Print(command)
+	return command
 }
 
 func printCommand(printOptions PrintCmdOptions, creds *sts.Credentials) string {

--- a/print.go
+++ b/print.go
@@ -35,6 +35,14 @@ func init() {
 	AwsServiceProvider = aws.NewAwsServiceProvider()
 }
 
+type OutputFormat string
+
+const (
+	OsShell    = "default"
+	Bash       = "bash"
+	Powershell = "powershell"
+)
+
 type PrintCmdOptions struct {
 	Org      string
 	User     string
@@ -42,6 +50,7 @@ type PrintCmdOptions struct {
 	NoMask   bool
 	Password string
 	Role     string
+	Output   OutputFormat
 }
 
 func GetUserInfoFromPrintCmdOptions(printOptions PrintCmdOptions) serviceProviders.UserInfo {
@@ -66,7 +75,14 @@ func Print(idProvider identityProviders.IdentityProvider, printOptions PrintCmdO
 	}
 
 	creds := AwsServiceProvider.GetCredentials(saml, printOptions.Role)
-	printDefaultFormat(creds)
+	switch printOptions.Output {
+	case Powershell:
+		printPowershell(creds)
+	case Bash:
+		printBash(creds)
+	default:
+		printDefaultFormat(creds)
+	}
 }
 
 func printPowershell(credentials *sts.Credentials) {

--- a/print.go
+++ b/print.go
@@ -73,20 +73,24 @@ func Print(idProvider identityProviders.IdentityProvider, printOptions PrintCmdO
 	}
 
 	creds := AwsServiceProvider.GetCredentials(saml, printOptions.Role)
+	command := printCommand(printOptions, creds)
+	fmt.Print(command)
+}
+
+func printCommand(printOptions PrintCmdOptions, creds *sts.Credentials) string {
 	switch printOptions.Output {
 	case Powershell:
-		printPowershell(creds)
+		return printPowershell(creds)
 	case Bash:
-		printBash(creds)
-	default:
-		printDefaultFormat(creds)
+		return printBash(creds)
 	}
+	return printDefaultFormat(creds)
 }
 
-func printPowershell(credentials *sts.Credentials) {
-	fmt.Printf(`$env:AWS_SESSION_TOKEN='%s'; $env:AWS_ACCESS_KEY_ID='%s'; $env:AWS_SECRET_ACCESS_KEY='%s'`, *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
+func printPowershell(credentials *sts.Credentials) string {
+	return fmt.Sprintf(`$env:AWS_SESSION_TOKEN='%s'; $env:AWS_ACCESS_KEY_ID='%s'; $env:AWS_SECRET_ACCESS_KEY='%s'`, *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
 }
 
-func printBash(credentials *sts.Credentials) {
-	fmt.Printf("export AWS_SESSION_TOKEN=%s\nexport AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s", *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
+func printBash(credentials *sts.Credentials) string {
+	return fmt.Sprintf("export AWS_SESSION_TOKEN=%s\nexport AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s", *credentials.SessionToken, *credentials.AccessKeyId, *credentials.SecretAccessKey)
 }

--- a/print_test.go
+++ b/print_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package bmx_test
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/Brightspace/bmx"
@@ -33,4 +37,72 @@ func TestMonkey(t *testing.T) {
 	bmx.AwsServiceProvider = &mocks.AwsServiceProviderMock{}
 	bmx.ConsoleReader = mocks.ConsoleReaderMock{}
 	bmx.Print(oktaClient, options)
+}
+
+func testBmxPrint(oktaClient *mocks.Mokta, options bmx.PrintCmdOptions) (string, error) {
+	stdout := os.Stdout
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = write
+
+	// Run bmx print and capture output
+	bmx.Print(oktaClient, options)
+
+	stdoutChan := make(chan string)
+	go func() {
+		var resp bytes.Buffer
+		io.Copy(&resp, read)
+		stdoutChan <- resp.String()
+	}()
+
+	write.Close()
+	os.Stdout = stdout
+	result := <-stdoutChan
+
+	return result, nil
+}
+
+func TestPShellPrint(t *testing.T) {
+	options := bmx.PrintCmdOptions{
+		Org:    "myorg",
+		Output: bmx.Powershell,
+	}
+
+	oktaClient := &mocks.Mokta{}
+
+	bmx.AwsServiceProvider = &mocks.AwsServiceProviderMock{}
+	bmx.ConsoleReader = mocks.ConsoleReaderMock{}
+
+	output, err := testBmxPrint(oktaClient, options)
+	if err != nil {
+		t.Errorf("Encountered exception while running bmx print, got: %s", err)
+	}
+
+	if !strings.Contains(output, "$env:") {
+		t.Errorf("Shell command was incorrect, got: %s, expected powershell", output)
+	}
+}
+
+func TestBashPrint(t *testing.T) {
+	options := bmx.PrintCmdOptions{
+		Org:    "myorg",
+		Output: bmx.Bash,
+	}
+
+	oktaClient := &mocks.Mokta{}
+
+	bmx.AwsServiceProvider = &mocks.AwsServiceProviderMock{}
+	bmx.ConsoleReader = mocks.ConsoleReaderMock{}
+
+	output, err := testBmxPrint(oktaClient, options)
+	if err != nil {
+		t.Errorf("Encountered exception while running bmx print, got: %s", err)
+	}
+	
+	if !strings.Contains(output, "export ") {
+		t.Errorf("Shell command was incorrect, got: %s, expected bash", output)
+	}
 }

--- a/print_unix.go
+++ b/print_unix.go
@@ -22,6 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func printDefaultFormat(credentials *sts.Credentials) {
-	printBash(credentials)
+func printDefaultFormat(credentials *sts.Credentials) string {
+	return printBash(credentials)
 }

--- a/print_windows.go
+++ b/print_windows.go
@@ -20,6 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func printDefaultFormat(credentials *sts.Credentials) {
-	printPowershell(credentials)
+func printDefaultFormat(credentials *sts.Credentials) string {
+	return printPowershell(credentials)
 }


### PR DESCRIPTION
At the moment the `bmx print` command assumes a 1-to-1 relation for the shell and operating system. This can be an issue when you are working with powershell in linux, or bash on windows. To resolve this, this PR adds support for an output option to control the shell command output.

This PR adds support for the command option `--output=[bash|powershell]` that determines the output command. The default output of the command is determined by the OS (linux=bash, windows=powershell), with the `--output` command.

Additionally, the `bmx.Print` function has been changed to emit the command, then print.

Resolves #187