### PR TITLE
Get AWS SAML Credentials from Okta

### DIFF
--- a/Bmx.Core/BmxCore.cs
+++ b/Bmx.Core/BmxCore.cs
@@ -80,7 +80,7 @@ namespace Bmx.Core {
 				selectedAccountIndex = PromptAccountSelection( accounts );
 			}
 
-			Console.WriteLine( $"Selected account: {accounts[selectedAccountIndex]}" );
+			var accountCredentials = _identityProvider.GetServiceProviderSaml( selectedAccountIndex );
 		}
 	}
 }

--- a/Bmx.Core/IIdentityProvider.cs
+++ b/Bmx.Core/IIdentityProvider.cs
@@ -6,5 +6,6 @@ namespace Bmx.Core {
 		Task<MfaOption[]> Authenticate( string username, string password );
 		Task<bool> ChallengeMfa( int selectedMfaIndex, string challengeResponse );
 		Task<string[]> GetAccounts( string accountType );
+		Task<string> GetServiceProviderSaml( int selectedAccountIndex );
 	}
 }


### PR DESCRIPTION
Partly closes #194 

This one is especially nasty. As mentioned in the issue, the "only" way to currently get SAML from Okta to use in order to auth against AWS (as well as to figure out the roles), is to parse an Okta provided webpage (its the same one where you choose which role you want to sign into AWS account as in browsers).

I've decided to break into two tasks: 
1. Okta IDP Service is only gonna to extract the SAML data
2. AWS Service will parse the SAML for Roles in the account as well  as exchange for tokens from STS. 

This PR addresses the first part

It's a bit of https://stackoverflow.com/a/1732454/4433646 :(