### PR TITLE
Exchange AWS SAML from Okta for AWS Access Tokens via STS

### DIFF
--- a/Bmx.CommandLine/CommandLine.cs
+++ b/Bmx.CommandLine/CommandLine.cs
@@ -14,7 +14,7 @@ namespace Bmx.CommandLine {
 
 		public CommandLine() {
 			// TODO: Fix this :| (ref: Program.cs)
-			_bmx = new BmxCore( new OktaClient( "d2l" ) );
+			_bmx = new BmxCore( new OktaClient(), new AwsClient() );
 			_cmdLineParser = BuildCommandLine().UseDefaults().Build();
 
 			_bmx.PromptUserName += GetUser;

--- a/Bmx.Core/BmxCore.cs
+++ b/Bmx.Core/BmxCore.cs
@@ -95,6 +95,8 @@ namespace Bmx.Core {
 			if( role == null || selectedRoleIndex == -1 ) {
 				selectedRoleIndex = PromptRoleSelection( roles );
 			}
+
+			var tokens = await _cloudProvider.GetTokens( selectedRoleIndex );
 		}
 	}
 }

--- a/Bmx.Core/BmxCore.cs
+++ b/Bmx.Core/BmxCore.cs
@@ -32,6 +32,8 @@ namespace Bmx.Core {
 			Debug.Assert( PromptAccountSelection != null, nameof(PromptAccountSelection) + " != null" );
 			Debug.Assert( PromptRoleSelection != null, nameof(PromptRoleSelection) + " != null" );
 
+			_identityProvider.SetOrganization( org );
+
 			if( user == null ) {
 				user = PromptUserName( _identityProvider.Name );
 			}

--- a/Bmx.Core/BmxCore.cs
+++ b/Bmx.Core/BmxCore.cs
@@ -80,7 +80,21 @@ namespace Bmx.Core {
 				selectedAccountIndex = PromptAccountSelection( accounts );
 			}
 
-			var accountCredentials = _identityProvider.GetServiceProviderSaml( selectedAccountIndex );
+			var accountCredentials = await _identityProvider.GetServiceProviderSaml( selectedAccountIndex );
+
+			_cloudProvider.SetSamlToken( accountCredentials );
+			var roles = _cloudProvider.GetRoles();
+			role = role?.ToLower();
+
+			int selectedRoleIndex = -1;
+
+			if( role != null ) {
+				selectedRoleIndex = Array.IndexOf( roles.Select( s => s.ToLower() ).ToArray(), role );
+			}
+
+			if( role == null || selectedRoleIndex == -1 ) {
+				selectedRoleIndex = PromptRoleSelection( roles );
+			}
 		}
 	}
 }

--- a/Bmx.Core/ICloudProvider.cs
+++ b/Bmx.Core/ICloudProvider.cs
@@ -1,6 +1,10 @@
-﻿namespace Bmx.Core {
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Bmx.Core {
 	public interface ICloudProvider {
 		void SetSamlToken( string encodedSaml );
 		string[] GetRoles();
+		Task<Dictionary<string, string>> GetTokens( int selectedRoleIndex );
 	}
 }

--- a/Bmx.Core/ICloudProvider.cs
+++ b/Bmx.Core/ICloudProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Bmx.Core {
+	public interface ICloudProvider {
+		void SetSamlToken( string encodedSaml );
+		string[] GetRoles();
+	}
+}

--- a/Bmx.Core/IIdentityProvider.cs
+++ b/Bmx.Core/IIdentityProvider.cs
@@ -3,6 +3,7 @@
 namespace Bmx.Core {
 	public interface IIdentityProvider {
 		public string Name { get; }
+		void SetOrganization( string organization );
 		Task<MfaOption[]> Authenticate( string username, string password );
 		Task<bool> ChallengeMfa( int selectedMfaIndex, string challengeResponse );
 		Task<string[]> GetAccounts( string accountType );

--- a/Bmx.Idp.Okta/OktaClient.cs
+++ b/Bmx.Idp.Okta/OktaClient.cs
@@ -24,16 +24,18 @@ namespace Bmx.Idp.Okta {
 		private OktaMfaFactor[] _oktaMfaFactors;
 		private OktaApp[] _oktaApps;
 
-		public OktaClient( string organization ) {
+		public OktaClient() {
 			_cookieContainer = new CookieContainer();
 			_httpClient = new HttpClient( new HttpClientHandler {CookieContainer = _cookieContainer} );
-
-			_httpClient.BaseAddress = new Uri( $"https://{organization}.okta.com/api/v1/" );
 			_httpClient.Timeout = TimeSpan.FromSeconds( 30 );
 			_httpClient.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( "application/json" ) );
 		}
 
 		public string Name => "Okta";
+
+		public void SetOrganization( string organization ) {
+			_httpClient.BaseAddress = new Uri( $"https://{organization}.okta.com/api/v1/" );
+		}
 
 		public async Task<MfaOption[]> Authenticate( string username, string password ) {
 			var authResp = await AuthenticateOkta( new AuthenticateOptions( username, password ) );

--- a/Bmx.Service.Aws/AwsClient.cs
+++ b/Bmx.Service.Aws/AwsClient.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using Bmx.Core;
+using Bmx.Service.Aws.Models;
+
+namespace Bmx.Service.Aws {
+	public class AwsClient : ICloudProvider {
+		private string _samlString;
+		private XmlDocument _samlToken;
+		private List<AwsRole> _awsRoles;
+
+		public void SetSamlToken( XmlDocument samlToken ) {
+			_samlToken = samlToken;
+		public void SetSamlToken( string encodedSaml ) {
+			_samlString = encodedSaml;
+
+			var samlStatements = _samlString.Split( ";" );
+			// Process the B64 Encoded SAML string to get valid XML doc
+			var samlString = new StringBuilder();
+			foreach( var inputValueString in samlStatements ) {
+				samlString.Append( HttpUtility.HtmlDecode( inputValueString ) );
+			}
+
+			var samlData = Convert.FromBase64String( samlString.ToString() );
+
+			_samlToken = new XmlDocument();
+			_samlToken.LoadXml( Encoding.UTF8.GetString( samlData ) );
+		}
+
+		public string[] GetRoles() {
+			var roleNodes = _samlToken.SelectNodes( "//*[@Name=\"https://aws.amazon.com/SAML/Attributes/Role\"]/*" );
+
+			_awsRoles = new List<AwsRole>();
+
+			foreach( XmlElement roleNode in roleNodes ) {
+				// SAML has value: <principal-arn>, <role-arn>
+				// The last part of the role-arn is a human readable name
+				var nodeContents = roleNode.InnerText.Split( "," );
+
+				_awsRoles.Add( new AwsRole {
+					PrincipalArn = nodeContents[0],
+					RoleArn = nodeContents[1],
+					RoleName = nodeContents[1].Split( "/" )[1]
+				} );
+			}
+
+			return _awsRoles.Select( role => role.RoleName ).ToArray();
+		}
+	}
+}

--- a/Bmx.Service.Aws/Models/AwsRole.cs
+++ b/Bmx.Service.Aws/Models/AwsRole.cs
@@ -1,0 +1,7 @@
+﻿namespace Bmx.Service.Aws.Models {
+	public struct AwsRole {
+		public string RoleName { get; set; }
+		public string PrincipalArn { get; set; }
+		public string RoleArn { get; set; }
+	}
+}


### PR DESCRIPTION
closes #194 

Add Cloud Provider (in this case AWS) which exchanges Okta provided SAML for short lived AWS tokens (these are what BMX outputs). 

- Parse out SAML from okta to Identify roles in the account,
- Use AWS SDK for .NET to Assume a role via the SAML

