### PR TITLE
Implement loading args from config

### DIFF
--- a/Bmx.CommandLine/Bmx.CommandLine.csproj
+++ b/Bmx.CommandLine/Bmx.CommandLine.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.6" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
     </ItemGroup>

--- a/Bmx.CommandLine/CommandLine.cs
+++ b/Bmx.CommandLine/CommandLine.cs
@@ -8,11 +8,13 @@ using Bmx.Core;
 
 namespace Bmx.CommandLine {
 	public class CommandLine {
-		private IBmxCore _bmx;
+		private readonly IBmxCore _bmx;
+		private readonly IBmxConfig _bmxConfig;
 		private readonly Parser _cmdLineParser;
 
-		public CommandLine(IBmxCore bmx) {
+		public CommandLine( IBmxCore bmx, IBmxConfig bmxConfig ) {
 			_bmx = bmx;
+			_bmxConfig = bmxConfig;
 			_cmdLineParser = BuildCommandLine().UseDefaults().Build();
 
 			_bmx.PromptUserName += GetUser;
@@ -63,8 +65,18 @@ namespace Bmx.CommandLine {
 			};
 		}
 
+
+		private static void BindConfiguration( IBmxConfig config, ref string org, ref string account, ref string role,
+			ref string user ) {
+			org ??= config.Org;
+			user ??= config.User;
+			account ??= config.Account;
+			role ??= config.Role;
+		}
+
 		private void ExecutePrint( string org, string account = null, string role = null, string user = null,
 			string output = null ) {
+			BindConfiguration( _bmxConfig, ref org, ref account, ref role, ref user );
 			_bmx.Print( org, account, role, user, output );
 		}
 

--- a/Bmx.CommandLine/IBmxConfig.cs
+++ b/Bmx.CommandLine/IBmxConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace Bmx.CommandLine {
+	public interface IBmxConfig {
+		public string Org { get; }
+		public string User { get; }
+		public string Account { get; }
+		public string Role { get; }
+		public string Profile { get; }
+	}
+}

--- a/Bmx.CommandLine/IniConfiguration.cs
+++ b/Bmx.CommandLine/IniConfiguration.cs
@@ -3,6 +3,8 @@ using System;
 using System.IO;
 using System.Security;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
 
 namespace Bmx.CommandLine {
 	public class IniConfiguration : IBmxConfig {
@@ -24,31 +26,28 @@ namespace Bmx.CommandLine {
 
 		private static IConfiguration GetConfiguration() {
 			// Main config is at ~/.bmx/config
-			var configLocation =
-				Path.Join( Environment.GetFolderPath( Environment.SpecialFolder.UserProfile ), ".bmx", "config" );
+			var configLocation = Path.Join( Environment.GetFolderPath( Environment.SpecialFolder.UserProfile ), ".bmx",
+				"config" );
 
 			// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
-			var shouldReadProjectConfig = ShouldReadProjectConfigs( configLocation );
+			var config = new ConfigurationBuilder().AddIniFile( configLocation, optional: true );
+
+			bool.TryParse( config.Build()["allow_project_configs"], out bool shouldReadProjectConfig );
+
 			string? projectConfigPath = null;
 
 			if( shouldReadProjectConfig ) {
 				projectConfigPath = GetProjectConfigPath();
 			}
 
-			var config = new ConfigurationBuilder().AddIniFile( configLocation );
-
 			if( shouldReadProjectConfig && projectConfigPath != null ) {
-				config.AddIniFile( projectConfigPath );
+				// Default file provider ignores files prefixed with ".", we need to provide our own as a result
+				var fileProvider =
+					new PhysicalFileProvider( Path.GetDirectoryName( projectConfigPath ), ExclusionFilters.None );
+				config.AddIniFile( fileProvider, Path.GetFileName( projectConfigPath ), optional: false, reloadOnChange: false );
 			}
 
 			return config.Build();
-		}
-
-		private static bool ShouldReadProjectConfigs( string primaryConfigLocation ) {
-			var config = new ConfigurationBuilder()
-				.AddIniFile( primaryConfigLocation ).Build();
-			bool.TryParse( config["allow_project_configs"], out bool allowProjectConfigs );
-			return allowProjectConfigs;
 		}
 
 		// Look from cwd up the directory chain all the way to root for a .bmx file

--- a/Bmx.CommandLine/IniConfiguration.cs
+++ b/Bmx.CommandLine/IniConfiguration.cs
@@ -1,0 +1,81 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Security;
+using Microsoft.Extensions.Configuration;
+
+namespace Bmx.CommandLine {
+	public class IniConfiguration : IBmxConfig {
+		public string? Org { get; }
+		public string? User { get; }
+		public string? Account { get; }
+		public string? Role { get; }
+		public string? Profile { get; }
+
+		public IniConfiguration() {
+			var config = GetConfiguration();
+
+			Org = config["org"];
+			User = config["user"];
+			Account = config["account"];
+			Role = config["role"];
+			Profile = config["profile"];
+		}
+
+		private static IConfiguration GetConfiguration() {
+			// Main config is at ~/.bmx/config
+			var configLocation =
+				Path.Join( Environment.GetFolderPath( Environment.SpecialFolder.UserProfile ), ".bmx", "config" );
+
+			// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
+			var shouldReadProjectConfig = ShouldReadProjectConfigs( configLocation );
+			string? projectConfigPath = null;
+
+			if( shouldReadProjectConfig ) {
+				projectConfigPath = GetProjectConfigPath();
+			}
+
+			var config = new ConfigurationBuilder().AddIniFile( configLocation );
+
+			if( shouldReadProjectConfig && projectConfigPath != null ) {
+				config.AddIniFile( projectConfigPath );
+			}
+
+			return config.Build();
+		}
+
+		private static bool ShouldReadProjectConfigs( string primaryConfigLocation ) {
+			var config = new ConfigurationBuilder()
+				.AddIniFile( primaryConfigLocation ).Build();
+			bool.TryParse( config["allow_project_configs"], out bool allowProjectConfigs );
+			return allowProjectConfigs;
+		}
+
+		// Look from cwd up the directory chain all the way to root for a .bmx file
+		private static string? GetProjectConfigPath() {
+			DirectoryInfo? currentDirectory = new DirectoryInfo( Directory.GetCurrentDirectory() );
+
+			while( currentDirectory != null ) {
+				try {
+					var bmxConfigFiles = currentDirectory.GetFiles( ".bmx" );
+
+					if( bmxConfigFiles.Length > 1 ) {
+						// TODO: Log this
+						return null;
+					}
+
+					if( bmxConfigFiles.Length == 1 ) {
+						return bmxConfigFiles[0].FullName;
+					}
+
+					currentDirectory = currentDirectory.Parent;
+				} catch( SecurityException ) {
+					// TODO: Log this
+					return null;
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/Bmx.CommandLine/Program.cs
+++ b/Bmx.CommandLine/Program.cs
@@ -9,7 +9,7 @@ namespace Bmx.CommandLine {
 		static void Main( string[] args ) {
 			var config = new IniConfiguration();
 			var services = ConfigureServices().BuildServiceProvider();
-			var cmdLine = new CommandLine( services.GetRequiredService<IBmxCore>() );
+			var cmdLine = new CommandLine( services.GetRequiredService<IBmxCore>(), config );
 			cmdLine.InvokeAsync( args ).Wait();
 		}
 

--- a/Bmx.CommandLine/Program.cs
+++ b/Bmx.CommandLine/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Bmx.CommandLine {
 	class Program {
 		static void Main( string[] args ) {
+			var config = new IniConfiguration();
 			var services = ConfigureServices().BuildServiceProvider();
 			var cmdLine = new CommandLine( services.GetRequiredService<IBmxCore>() );
 			cmdLine.InvokeAsync( args ).Wait();


### PR DESCRIPTION
Closes #201 

Did some odd stuff for merging values for runtime args to values found in configs, System.CommandLine doesn't have a good solution for this [at the moment](https://github.com/dotnet/command-line-api/issues/857).

Aside:
That lib has a lot of in-draft/wip features so I think it makes sense to do some things manually for now.