### PR TITLE
Refactor Identity and Cloud provider services to be stateless.

### DIFF
--- a/Bmx.CommandLine/CommandLine.cs
+++ b/Bmx.CommandLine/CommandLine.cs
@@ -5,14 +5,20 @@ using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 using Bmx.Core;
+using Bmx.Core.State;
 
 namespace Bmx.CommandLine {
-	public class CommandLine {
-		private readonly IBmxCore _bmx;
+	public class CommandLine<TAuthenticateState, TAuthenticatedState, TAccountState, TRoleState>
+		where TAuthenticateState : IAuthenticateState
+		where TAuthenticatedState : IAuthenticatedState
+		where TAccountState : IAccountState
+		where TRoleState : IRoleState {
+		private readonly IBmxCore<TAuthenticateState, TAuthenticatedState, TAccountState, TRoleState> _bmx;
 		private readonly IBmxConfig _bmxConfig;
 		private readonly Parser _cmdLineParser;
 
-		public CommandLine( IBmxCore bmx, IBmxConfig bmxConfig ) {
+		public CommandLine( IBmxCore<TAuthenticateState, TAuthenticatedState, TAccountState, TRoleState> bmx,
+			IBmxConfig bmxConfig ) {
 			_bmx = bmx;
 			_bmxConfig = bmxConfig;
 			_cmdLineParser = BuildCommandLine().UseDefaults().Build();

--- a/Bmx.CommandLine/IniConfiguration.cs
+++ b/Bmx.CommandLine/IniConfiguration.cs
@@ -44,7 +44,8 @@ namespace Bmx.CommandLine {
 				// Default file provider ignores files prefixed with ".", we need to provide our own as a result
 				var fileProvider =
 					new PhysicalFileProvider( Path.GetDirectoryName( projectConfigPath ), ExclusionFilters.None );
-				config.AddIniFile( fileProvider, Path.GetFileName( projectConfigPath ), optional: false, reloadOnChange: false );
+				config.AddIniFile( fileProvider, Path.GetFileName( projectConfigPath ), optional: false,
+					reloadOnChange: false );
 			}
 
 			return config.Build();

--- a/Bmx.CommandLine/Program.cs
+++ b/Bmx.CommandLine/Program.cs
@@ -1,7 +1,9 @@
 ﻿using Amazon.SecurityToken;
 using Bmx.Core;
 using Bmx.Idp.Okta;
+using Bmx.Idp.Okta.State;
 using Bmx.Service.Aws;
+using Bmx.Service.Aws.State;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bmx.CommandLine {
@@ -9,7 +11,11 @@ namespace Bmx.CommandLine {
 		static void Main( string[] args ) {
 			var config = new IniConfiguration();
 			var services = ConfigureServices().BuildServiceProvider();
-			var cmdLine = new CommandLine( services.GetRequiredService<IBmxCore>(), config );
+			var cmdLine =
+				new CommandLine<OktaAuthenticateState, OktaAuthenticatedState, OktaAccountState, AwsRoleState>(
+					services
+						.GetRequiredService<IBmxCore<OktaAuthenticateState, OktaAuthenticatedState, OktaAccountState,
+							AwsRoleState>>(), config );
 			cmdLine.InvokeAsync( args ).Wait();
 		}
 
@@ -21,10 +27,14 @@ namespace Bmx.CommandLine {
 			services.AddSingleton<IAmazonSecurityTokenService, AmazonSecurityTokenServiceClient>();
 
 			// TODO: Move state out to BmxCore and make these two transient
-			services.AddSingleton<IIdentityProvider, OktaClient>();
-			services.AddSingleton<ICloudProvider, AwsClient>();
+			services
+				.AddSingleton<IIdentityProvider<OktaAuthenticateState, OktaAuthenticatedState, OktaAccountState>,
+					OktaClient>();
+			services.AddSingleton<ICloudProvider<AwsRoleState>, AwsClient>();
 
-			services.AddSingleton<IBmxCore, BmxCore>();
+			services
+				.AddSingleton<IBmxCore<OktaAuthenticateState, OktaAuthenticatedState, OktaAccountState, AwsRoleState>,
+					BmxCore<OktaAuthenticateState, OktaAuthenticatedState, OktaAccountState, AwsRoleState>>();
 			return services;
 		}
 	}

--- a/Bmx.Core/Events.cs
+++ b/Bmx.Core/Events.cs
@@ -6,6 +6,7 @@
 	public delegate int PromptMfaTypeHandler( string[] mfaOptions );
 
 	public delegate string PromptMfaInputHandler( string mfaInputPrompt );
+
 	public delegate int PromptAccountSelectHandler( string[] accounts );
 
 	public delegate int PromptRoleSelectionHandler( string[] roles );

--- a/Bmx.Core/IBmxCore.cs
+++ b/Bmx.Core/IBmxCore.cs
@@ -1,7 +1,11 @@
-﻿namespace Bmx.Core
-{
-	public interface IBmxCore
-	{
+﻿using Bmx.Core.State;
+
+namespace Bmx.Core {
+	public interface IBmxCore<TAuthenticateState, TAuthenticatedState, TAccountState, TRoleState>
+		where TAuthenticateState : IAuthenticateState
+		where TAuthenticatedState : IAuthenticatedState
+		where TAccountState : IAccountState
+		where TRoleState : IRoleState {
 		event PromptUserNameHandler PromptUserName;
 		event PromptUserPasswordHandler PromptUserPassword;
 		event PromptMfaTypeHandler PromptMfaType;

--- a/Bmx.Core/ICloudProvider.cs
+++ b/Bmx.Core/ICloudProvider.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bmx.Core.State;
 
 namespace Bmx.Core {
-	public interface ICloudProvider {
-		void SetSamlToken( string encodedSaml );
-		string[] GetRoles();
-		Task<Dictionary<string, string>> GetTokens( int selectedRoleIndex );
+	public interface ICloudProvider<TRoleState> where TRoleState : IRoleState {
+		TRoleState GetRoles( string encodedSaml );
+		Task<Dictionary<string, string>> GetTokens( TRoleState state, int selectedRoleIndex );
 	}
 }

--- a/Bmx.Core/IIdentityProvider.cs
+++ b/Bmx.Core/IIdentityProvider.cs
@@ -1,12 +1,19 @@
 ﻿using System.Threading.Tasks;
+using Bmx.Core.State;
 
 namespace Bmx.Core {
-	public interface IIdentityProvider {
+	public interface IIdentityProvider<TAuthenticateState, TAuthenticatedState, TAccountState>
+		where TAuthenticateState : IAuthenticateState
+		where TAuthenticatedState : IAuthenticatedState
+		where TAccountState : IAccountState {
 		public string Name { get; }
 		void SetOrganization( string organization );
-		Task<MfaOption[]> Authenticate( string username, string password );
-		Task<bool> ChallengeMfa( int selectedMfaIndex, string challengeResponse );
-		Task<string[]> GetAccounts( string accountType );
-		Task<string> GetServiceProviderSaml( int selectedAccountIndex );
+		Task<TAuthenticateState> Authenticate( string username, string password );
+
+		Task<TAuthenticatedState> ChallengeMfa( TAuthenticateState state, int selectedMfaIndex,
+			string challengeResponse );
+
+		Task<TAccountState> GetAccounts( TAuthenticatedState state, string accountType );
+		Task<string> GetServiceProviderSaml( TAccountState state, int selectedAccountIndex );
 	}
 }

--- a/Bmx.Core/State/IAccountState.cs
+++ b/Bmx.Core/State/IAccountState.cs
@@ -1,0 +1,6 @@
+﻿namespace Bmx.Core.State
+{
+	public interface IAccountState {
+		string[] Accounts { get; }
+	}
+}

--- a/Bmx.Core/State/IAuthenticateState.cs
+++ b/Bmx.Core/State/IAuthenticateState.cs
@@ -1,0 +1,6 @@
+﻿namespace Bmx.Core.State
+{
+	public interface IAuthenticateState {
+		MfaOption[] MfaOptions { get; }
+	}
+}

--- a/Bmx.Core/State/IAuthenticatedState.cs
+++ b/Bmx.Core/State/IAuthenticatedState.cs
@@ -1,0 +1,6 @@
+﻿namespace Bmx.Core.State
+{
+	public interface IAuthenticatedState {
+		bool SuccessfulAuthentication { get; }
+	}
+}

--- a/Bmx.Core/State/IRoleState.cs
+++ b/Bmx.Core/State/IRoleState.cs
@@ -1,0 +1,6 @@
+﻿namespace Bmx.Core.State
+{
+	public interface IRoleState {
+		string[] Roles { get; }
+	}
+}

--- a/Bmx.Idp.Okta/State/OktaAccountState.cs
+++ b/Bmx.Idp.Okta/State/OktaAccountState.cs
@@ -7,12 +7,10 @@ namespace Bmx.Idp.Okta.State {
 		public OktaAccountState( OktaApp[] oktaApps, string accountType ) {
 			OktaApps = oktaApps;
 			AccountType = accountType;
+			Accounts = OktaApps.Where( app => app.AppName == AccountType ).Select( app => app.Label ).ToArray();
 		}
 
-		public string[] Accounts {
-			get => OktaApps.Where( app => app.AppName == AccountType ).Select( app => app.Label ).ToArray();
-		}
-
+		public string[] Accounts { get; }
 		internal string AccountType { get; }
 		internal OktaApp[] OktaApps { get; }
 	}

--- a/Bmx.Idp.Okta/State/OktaAccountState.cs
+++ b/Bmx.Idp.Okta/State/OktaAccountState.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+using Bmx.Core.State;
+using Bmx.Idp.Okta.Models;
+
+namespace Bmx.Idp.Okta.State {
+	public class OktaAccountState : IAccountState {
+		public OktaAccountState( OktaApp[] oktaApps, string accountType ) {
+			OktaApps = oktaApps;
+			AccountType = accountType;
+		}
+
+		public string[] Accounts {
+			get => OktaApps.Where( app => app.AppName == AccountType ).Select( app => app.Label ).ToArray();
+		}
+
+		internal string AccountType { get; }
+		internal OktaApp[] OktaApps { get; }
+	}
+}

--- a/Bmx.Idp.Okta/State/OktaAuthenticateState.cs
+++ b/Bmx.Idp.Okta/State/OktaAuthenticateState.cs
@@ -8,10 +8,7 @@ namespace Bmx.Idp.Okta.State {
 		public OktaAuthenticateState( string oktaStateToken, OktaMfaFactor[] oktaMfaFactors ) {
 			OktaStateToken = oktaStateToken;
 			OktaMfaFactors = oktaMfaFactors;
-		}
-
-		public MfaOption[] MfaOptions {
-			get => OktaMfaFactors.Select( factor => {
+			MfaOptions = OktaMfaFactors.Select( factor => {
 				if( factor.FactorType.Contains( "token" ) || factor.FactorType.Contains( "sms" ) ) {
 					return new MfaOption( factor.FactorType, MfaType.Challenge );
 				}
@@ -24,6 +21,7 @@ namespace Bmx.Idp.Okta.State {
 			} ).ToArray();
 		}
 
+		public MfaOption[] MfaOptions { get; }
 		// Store auth state for later steps (MFA challenge verify etc...)
 		internal string OktaStateToken { get; }
 		internal OktaMfaFactor[] OktaMfaFactors { get; }

--- a/Bmx.Idp.Okta/State/OktaAuthenticateState.cs
+++ b/Bmx.Idp.Okta/State/OktaAuthenticateState.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using Bmx.Core;
+using Bmx.Core.State;
+using Bmx.Idp.Okta.Models;
+
+namespace Bmx.Idp.Okta.State {
+	public class OktaAuthenticateState : IAuthenticateState {
+		public OktaAuthenticateState( string oktaStateToken, OktaMfaFactor[] oktaMfaFactors ) {
+			OktaStateToken = oktaStateToken;
+			OktaMfaFactors = oktaMfaFactors;
+		}
+
+		public MfaOption[] MfaOptions {
+			get => OktaMfaFactors.Select( factor => {
+				if( factor.FactorType.Contains( "token" ) || factor.FactorType.Contains( "sms" ) ) {
+					return new MfaOption( factor.FactorType, MfaType.Challenge );
+				}
+
+				if( factor.FactorType.Contains( "push" ) ) {
+					return new MfaOption( factor.FactorType, MfaType.Verify );
+				}
+
+				return new MfaOption( factor.FactorType, MfaType.Unknown );
+			} ).ToArray();
+		}
+
+		// Store auth state for later steps (MFA challenge verify etc...)
+		internal string OktaStateToken { get; }
+		internal OktaMfaFactor[] OktaMfaFactors { get; }
+	}
+}

--- a/Bmx.Idp.Okta/State/OktaAuthenticatedState.cs
+++ b/Bmx.Idp.Okta/State/OktaAuthenticatedState.cs
@@ -1,0 +1,13 @@
+﻿using Bmx.Core.State;
+
+namespace Bmx.Idp.Okta.State {
+	public class OktaAuthenticatedState : IAuthenticatedState {
+		public OktaAuthenticatedState( bool successfulAuthentication, string oktaSessionToken ) {
+			SuccessfulAuthentication = successfulAuthentication;
+			OktaSessionToken = oktaSessionToken;
+		}
+
+		public bool SuccessfulAuthentication { get; }
+		internal string OktaSessionToken { get; }
+	}
+}

--- a/Bmx.Service.Aws/State/AwsRoleState.cs
+++ b/Bmx.Service.Aws/State/AwsRoleState.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Bmx.Core.State;
+using Bmx.Service.Aws.Models;
+
+namespace Bmx.Service.Aws.State {
+	public class AwsRoleState : IRoleState {
+		public AwsRoleState( List<AwsRole> awsRoles, string samlString ) {
+			AwsRoles = awsRoles;
+			SamlString = samlString;
+		}
+
+		public string[] Roles => AwsRoles.Select( role => role.RoleName ).ToArray();
+		internal List<AwsRole> AwsRoles { get; }
+		internal string SamlString { get; }
+	}
+}

--- a/Bmx.Service.Aws/State/AwsRoleState.cs
+++ b/Bmx.Service.Aws/State/AwsRoleState.cs
@@ -8,9 +8,10 @@ namespace Bmx.Service.Aws.State {
 		public AwsRoleState( List<AwsRole> awsRoles, string samlString ) {
 			AwsRoles = awsRoles;
 			SamlString = samlString;
+			Roles = AwsRoles.Select( role => role.RoleName ).ToArray();
 		}
 
-		public string[] Roles => AwsRoles.Select( role => role.RoleName ).ToArray();
+		public string[] Roles { get; }
 		internal List<AwsRole> AwsRoles { get; }
 		internal string SamlString { get; }
 	}


### PR DESCRIPTION
More of an experimental thing, if it looks too silly / convoluted please feel free to say so, its not essential that it's merged.

BMX is primarily about talking to Okta (beyond a generic interface of course). The Okta Authentication API is stateful with for example a state token during authentication which is then exchanged for a session token. 

Its easy enough to store this state internally to OktaIdentityProvider without leaking implementation data to BMXCore (the project that orchestrates the various calls to Identity and Cloud Providers. [Workflow diagram](https://github.com/Brightspace/bmx/wiki/Architecture).

What this means though is that for example Identity Service has very strong sequential coupling, calls cannot be called out of order or skipped. Which is a code smell + it makes unit testing painful: 
ex:

`
_identityProvider.Authenticate(...);
// This call can't happen till .Authenticate has been called etc..., the state is stored internal to _identityProvider
_identityProvider.GetAccounts(...)
`
Couple of solutions:
Maintain state within BmxCore, passed to service calls as arguments (i.e GetAccounts requires a state object that can only be received from Authenticate call) :
1. Leak implementation details (of Okta state) directly to BmxCore
2. Have BmxCore interact with state as generics (implementations such as OktaIdentityProvider will use more specific types) <- What I've implemented in this PR

An alternate suggestion on SE StackExchange (where I asked this)  was to move the state to a wrapper class maintaining state that can be disposed afterwards. Don't see how that solves the problem of sequential coupling IMO. 

PS:  SE Stackexchange thread for a more general [answer](https://softwareengineering.stackexchange.com/questions/412544/avoiding-sequential-coupling-while-maintaining-separation-of-concerns)

Long PR with a lot of diff >.< 