### PR TITLE
dotnet7: Recreate dotnet cli

### DIFF
--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -1,0 +1,25 @@
+public class Authenticator {
+	public static void Authenticate( string? org, string? user, bool nomask ) {
+		// TODO: Add authenticating from cache
+
+		Console.Write( "Okta Password: " );
+		var password = "";
+		if( nomask ) {
+			password = Console.ReadLine();
+		} else {
+			while( true ) {
+				var input = Console.ReadKey( intercept: true );
+				if( input.Key == ConsoleKey.Enter ) {
+					Console.Write( '\n' );
+					break;
+				} else if( input.Key == ConsoleKey.Backspace && password.Length > 0 ) {
+					password = password.Remove( password.Length - 1, 1 );
+				} else if( !char.IsControl( input.KeyChar ) ) {
+					password += input.KeyChar;
+				}
+			}
+		}
+
+		// TODO: Add authenticaion into Okta Client. If error, print and terminate.
+	}
+}

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
 		<PackageReference Include="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
 		<PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/D2L.Bmx/Print.cs
+++ b/src/D2L.Bmx/Print.cs
@@ -1,0 +1,70 @@
+public class Print {
+
+	public static void PrintHandler( string? org, string? user, string? account, string? role, int? duration, bool nomask, string? output ) {
+
+		// TODO: Get values of org, user, account, and role from the config file and assign them locally. This way we can check if
+		// values are null to see if they have been set through the commandline or config file
+
+		// ask user to input org if org flag isn't set
+		if( string.IsNullOrEmpty( org ) ) {
+			// TODO: also print out --help output
+			Console.WriteLine( "Error: required flag(s) \"org\"" );
+			return;
+		};
+
+		// ask user to input username if user flag isn't set
+		if( string.IsNullOrEmpty( user ) ) {
+			Console.Write( "Okta Username: " );
+			// there is currently no input validation for the username in the golang build, but it can be added
+			user = Console.ReadLine();
+		};
+
+		// Asks for user password input, or logs them in through caches
+		Authenticator.Authenticate( org, user, nomask );
+
+		// TODO: replace placeholder values with actual values
+		var accounts = new[] { "Dev-Slims", "Dev-Toolmon", "Int-Dev-NDE" };
+		var roles = new[] { "Dev-Slims-ReadOnly", "Dev-Slims-Admin" };
+
+		if( string.IsNullOrEmpty( account ) ) {
+			Console.WriteLine( "Available accounts:" );
+			for( int i = 0; i < accounts.Length; i++ ) {
+				Console.WriteLine( $"[{i + 1}] {accounts[i]}" );
+			}
+			Console.Write( "Select an account: " );
+			if( int.TryParse( Console.ReadLine(), out int index ) ) {
+				if( index > accounts.Length || index < 1 ) {
+					Console.WriteLine( "Error: Invalid selection" );
+					return;
+				}
+				account = accounts[index - 1];
+			} else {
+				Console.WriteLine( "Error: Please enter an integer" );
+				return;
+			}
+		}
+
+		if( string.IsNullOrEmpty( role ) ) {
+			Console.WriteLine( "Available roles:" );
+			for( int i = 0; i < roles.Length; i++ ) {
+				Console.WriteLine( $"[{i + 1}] {roles[i]}" );
+			}
+			Console.Write( "Select a role: " );
+			if( int.TryParse( Console.ReadLine(), out int index ) ) {
+				if( index > roles.Length || index < 1 ) {
+					Console.WriteLine( "Invalid selection" );
+					return;
+				}
+				role = roles[index - 1];
+			} else {
+				Console.WriteLine( "Please enter an integer" );
+				return;
+			}
+		}
+
+		// TODO: Replace with call to function to get AWS credentials and print them on screen
+		Console.WriteLine( $" Org: {org}\n User: {user}\n Account: {account}\n Role: {role}\n Duration: {duration}\n nomask: {nomask}" );
+	}
+
+
+}

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -69,5 +69,5 @@ writeCommand.SetHandler(
 
 rootCommand.Add( writeCommand );
 
-// version and help commands are not implemented because they can be called as flags (--version and --help respectively)
+// version and help commands are not implemented. they can be called as flags (--version and --help respectively). However they can be added later if necessary
 return await rootCommand.InvokeAsync( args );

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -1,3 +1,73 @@
+using System.CommandLine;
 
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine( "Hello, World!" );
+var orgOption = new Option<string?>(
+	name: "--org",
+	description: "the okta org api to target" );
+var userOption = new Option<string?>(
+	name: "--user",
+	description: "the user to authenticate with" );
+var accountOption = new Option<string?>(
+	name: "--account",
+	description: "the account name to auth against" );
+var roleOption = new Option<string?>(
+	name: "--role",
+	description: "the desired role to assume" );
+var durationOption = new Option<int?>(
+	name: "--duration",
+	description: "duration of session in minutes",
+	getDefaultValue: () => 60 );
+var nomaskOption = new Option<bool>(
+	name: "--nomask",
+	description: "set to not mask the password, helps with debugging",
+	getDefaultValue: () => false );
+var printOutputOption = new Option<string?>(
+	name: "--output",
+	description: "the output format [bash|powershell]" );
+var writeOutputOption = new Option<string?>(
+	name: "--output",
+	description: "write to the specified file instead of ~/.aws/credentials" );
+var profileOption = new Option<string?>(
+	name: "--profile",
+	description: "aws profile name" );
+
+var rootCommand = new RootCommand();
+
+var printCommand = new Command( "print", "Print the long stuff to screen" )
+	{
+		accountOption,
+		durationOption,
+		nomaskOption,
+		orgOption,
+		printOutputOption,
+		roleOption,
+		userOption,
+	};
+
+printCommand.SetHandler(
+	Print.PrintHandler,
+	orgOption, userOption, accountOption, roleOption, durationOption, nomaskOption, printOutputOption
+ );
+
+rootCommand.Add( printCommand );
+
+var writeCommand = new Command( "write", "Write to aws credential file" )
+	{
+		accountOption,
+		durationOption,
+		nomaskOption,
+		orgOption,
+		writeOutputOption,
+		profileOption,
+		roleOption,
+		userOption,
+	};
+
+writeCommand.SetHandler(
+	Write.WriteHandler,
+	orgOption, userOption, accountOption, roleOption, durationOption, nomaskOption, writeOutputOption, profileOption
+ );
+
+rootCommand.Add( writeCommand );
+
+// version and help commands are not implemented because they can be called as flags (--version and --help respectively)
+return await rootCommand.InvokeAsync( args );

--- a/src/D2L.Bmx/Write.cs
+++ b/src/D2L.Bmx/Write.cs
@@ -1,0 +1,87 @@
+
+public class Write {
+	public static void WriteHandler( string? org, string? user, string? account, string? role, int? duration, bool nomask, string? output, string? profile ) {
+		// TODO: Get values of org, user, account, role and profile from the config file and assign them locally. This way we can check if
+		// values are null to see if they have been set through the commandline or config file
+
+		var requiredUnsetFlags = new List<string>();
+
+		// ask user to input org if org flag isn't set
+		if( string.IsNullOrEmpty( org ) ) {
+			requiredUnsetFlags.Add( "\"org\"" );
+		};
+
+		// check if profile flag has been set
+		if( string.IsNullOrEmpty( profile ) ) {
+			requiredUnsetFlags.Add( "\"profile\"" );
+		}
+
+		if( requiredUnsetFlags.Count != 0 ) {
+			Console.Write( "Error: required flag(s) " );
+			for( int i = 0; i < requiredUnsetFlags.Count; i++ ) {
+				Console.Write( requiredUnsetFlags.ElementAt( i ) );
+				if( i < requiredUnsetFlags.Count - 1 ) {
+					Console.Write( ", " );
+				} else {
+					Console.WriteLine( " not set" );
+				}
+			}
+			// Also print the output of the help command
+			return;
+		}
+
+		// ask user to input username if user flag isn't set
+		if( string.IsNullOrEmpty( user ) ) {
+			Console.Write( "Okta Username: " );
+			// there is currently no input validation for the username in the golang build, but it can be added
+			user = Console.ReadLine();
+		};
+
+		// Asks for user password input, or logs them in through caches
+		Authenticator.Authenticate( org, user, nomask );
+
+		// TODO: replace placeholder values with actual values
+		var accounts = new[] { "Dev-Slims", "Dev-Toolmon", "Int-Dev-NDE" };
+		var roles = new[] { "Dev-Slims-ReadOnly", "Dev-Slims-Admin" };
+
+		if( string.IsNullOrEmpty( account ) ) {
+			Console.WriteLine( "Available accounts:" );
+			for( int i = 0; i < accounts.Length; i++ ) {
+				Console.WriteLine( $"[{i + 1}] {accounts[i]}" );
+			}
+			Console.Write( "Select an account: " );
+			if( int.TryParse( Console.ReadLine(), out int index ) ) {
+				if( index > accounts.Length || index < 1 ) {
+					Console.WriteLine( "Error: Invalid selection" );
+					return;
+				}
+				account = accounts[index - 1];
+			} else {
+				Console.WriteLine( "Error: Please enter an integer" );
+				return;
+			}
+		}
+
+		if( string.IsNullOrEmpty( role ) ) {
+			Console.WriteLine( "Available roles:" );
+			for( int i = 0; i < roles.Length; i++ ) {
+				Console.WriteLine( $"[{i + 1}] {roles[i]}" );
+			}
+			Console.Write( "Select a role: " );
+			if( int.TryParse( Console.ReadLine(), out int index ) ) {
+				if( index > roles.Length || index < 1 ) {
+					Console.WriteLine( "Error: Invalid selection" );
+					return;
+				}
+				role = roles[index - 1];
+			} else {
+				Console.WriteLine( "Error: Please enter an integer" );
+				return;
+			}
+		}
+
+		// TODO: Replace with call to function to get AWS credentials and write them to credentials file
+		Console.WriteLine( $" Org: {org}\n Profile: {profile}\n User: {user}\n Account: {account}\n Role: {role}\n Duration: {duration}\n nomask: {nomask}" );
+	}
+
+}

--- a/src/D2L.Bmx/Write.cs
+++ b/src/D2L.Bmx/Write.cs
@@ -4,23 +4,23 @@ public class Write {
 		// TODO: Get values of org, user, account, role and profile from the config file and assign them locally. This way we can check if
 		// values are null to see if they have been set through the commandline or config file
 
-		var requiredUnsetFlags = new List<string>();
+		var unsetFlags = new List<string>();
 
 		// ask user to input org if org flag isn't set
 		if( string.IsNullOrEmpty( org ) ) {
-			requiredUnsetFlags.Add( "\"org\"" );
+			unsetFlags.Add( "\"org\"" );
 		};
 
 		// check if profile flag has been set
 		if( string.IsNullOrEmpty( profile ) ) {
-			requiredUnsetFlags.Add( "\"profile\"" );
+			unsetFlags.Add( "\"profile\"" );
 		}
 
-		if( requiredUnsetFlags.Count != 0 ) {
+		if( unsetFlags.Count != 0 ) {
 			Console.Write( "Error: required flag(s) " );
-			for( int i = 0; i < requiredUnsetFlags.Count; i++ ) {
-				Console.Write( requiredUnsetFlags.ElementAt( i ) );
-				if( i < requiredUnsetFlags.Count - 1 ) {
+			for( int i = 0; i < unsetFlags.Count; i++ ) {
+				Console.Write( unsetFlags.ElementAt( i ) );
+				if( i < unsetFlags.Count - 1 ) {
 					Console.Write( ", " );
 				} else {
 					Console.WriteLine( " not set" );


### PR DESCRIPTION
### Why

Recreates the base CLI using dotnet. Does not yet read from config files.

To run the CLI, use the BMX commands as usual, except replace `bmx` with `dotnet run -- `

Ex. `bmx print --org d2l` becomes `dotnet run -- print --org d2l`