### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ jobs:
   build:
     strategy:
       matrix:
-        architecture: [x64]
         include:
           - machine: windows-latest
             platform: win
@@ -33,6 +32,5 @@ jobs:
         shell: pwsh
         env:
           PLATFORM: ${{ matrix.platform }}
-          ARCHITECTURE: ${{ matrix.architecture }}
         working-directory: src/D2L.Bmx
-        run: dotnet publish -r $env:PLATFORM-$env:ARCHITECTURE -c Release
+        run: dotnet publish -r $env:PLATFORM-x64 -c Release


### PR DESCRIPTION
I think because of that architecture value in the matrix the `include` part wasn't working. Or maybe it's something else. I just noticed it was only being run on linux which is the last entry

### Why

