### PR TITLE
add Roslynator and fix nonconformance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -1,3 +1,5 @@
+namespace D2L.Bmx;
+
 public class Authenticator {
 	public static void Authenticate( string? org, string? user, bool nomask ) {
 		// TODO: Add authenticating from cache

--- a/src/D2L.Bmx/Print.cs
+++ b/src/D2L.Bmx/Print.cs
@@ -1,6 +1,15 @@
-public class Print {
+namespace D2L.Bmx;
 
-	public static void PrintHandler( string? org, string? user, string? account, string? role, int? duration, bool nomask, string? output ) {
+public class Print {
+	public static void PrintHandler(
+		string? org,
+		string? user,
+		string? account,
+		string? role,
+		int? duration,
+		bool nomask,
+		string? output
+	) {
 
 		// TODO: Get values of org, user, account, and role from the config file and assign them locally. This way we can check if
 		// values are null to see if they have been set through the commandline or config file
@@ -63,8 +72,12 @@ public class Print {
 		}
 
 		// TODO: Replace with call to function to get AWS credentials and print them on screen
-		Console.WriteLine( $" Org: {org}\n User: {user}\n Account: {account}\n Role: {role}\n Duration: {duration}\n nomask: {nomask}" );
+		Console.WriteLine( string.Join( '\n',
+			$"Org: {org}",
+			$"User: {user}",
+			$"Account: {account}",
+			$"Role: {role}",
+			$"Duration: {duration}",
+			$"nomask: {nomask}" ) );
 	}
-
-
 }

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using D2L.Bmx;
 
 var orgOption = new Option<string?>(
 	name: "--org",
@@ -14,12 +15,12 @@ var roleOption = new Option<string?>(
 	description: "the desired role to assume" );
 var durationOption = new Option<int?>(
 	name: "--duration",
-	description: "duration of session in minutes",
-	getDefaultValue: () => 60 );
+	getDefaultValue: () => 60,
+	description: "duration of session in minutes" );
 var nomaskOption = new Option<bool>(
 	name: "--nomask",
-	description: "set to not mask the password, helps with debugging",
-	getDefaultValue: () => false );
+	getDefaultValue: () => false,
+	description: "set to not mask the password, helps with debugging" );
 var printOutputOption = new Option<string?>(
 	name: "--output",
 	description: "the output format [bash|powershell]" );

--- a/src/D2L.Bmx/Write.cs
+++ b/src/D2L.Bmx/Write.cs
@@ -1,6 +1,16 @@
+namespace D2L.Bmx;
 
 public class Write {
-	public static void WriteHandler( string? org, string? user, string? account, string? role, int? duration, bool nomask, string? output, string? profile ) {
+	public static void WriteHandler(
+		string? org,
+		string? user,
+		string? account,
+		string? role,
+		int? duration,
+		bool nomask,
+		string? output,
+		string? profile
+	) {
 		// TODO: Get values of org, user, account, role and profile from the config file and assign them locally. This way we can check if
 		// values are null to see if they have been set through the commandline or config file
 
@@ -81,7 +91,13 @@ public class Write {
 		}
 
 		// TODO: Replace with call to function to get AWS credentials and write them to credentials file
-		Console.WriteLine( $" Org: {org}\n Profile: {profile}\n User: {user}\n Account: {account}\n Role: {role}\n Duration: {duration}\n nomask: {nomask}" );
+		Console.WriteLine( string.Join( '\n',
+			$"Org: {org}",
+			$"Profile: {profile}",
+			$"User: {user}",
+			$"Account: {account}",
+			$"Role: {role}",
+			$"Duration: {duration}",
+			$"nomask: {nomask}" ) );
 	}
-
 }


### PR DESCRIPTION
We use Roslynator analyzers in all our team's C# codebase and have some rules (already defined in .editorconfig) we enforce at build time.
Noticed that bmx didn't have them.