### PR TITLE
Remove Okta from method names

### DIFF
--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -30,7 +30,7 @@ internal class Authenticator {
 
 		oktaApi.SetOrganization( org );
 
-		var authState = await oktaApi.AuthenticateOktaAsync( new AuthenticateOptions( user, password ) )
+		var authState = await oktaApi.AuthenticateAsync( new AuthenticateOptions( user, password ) )
 			.ConfigureAwait( false );
 
 		OktaAuthenticatedState? authenticatedState = default;
@@ -46,7 +46,7 @@ internal class Authenticator {
 			if( selectedMfa.Type == MfaType.Challenge ) {
 				mfaInput = PromptMfaInput( "Code" );
 			} else if( selectedMfa.Type == MfaType.Sms ) {
-				await oktaApi.IssueMfaChallengeOktaAsync( authState, selectedMfaIndex - 1 );
+				await oktaApi.IssueMfaChallengeAsync( authState, selectedMfaIndex - 1 );
 				mfaInput = PromptMfaInput( "Code" );
 			} else if( selectedMfa.Type == MfaType.Question ) {
 				mfaInput = PromptMfaInput( "Answer" );
@@ -55,7 +55,7 @@ internal class Authenticator {
 				PromptMfaInput( selectedMfa.Name );
 				throw new NotImplementedException();
 			}
-			authenticatedState = await oktaApi.AuthenticateChallengeMfaOktaAsync( authState, selectedMfaIndex - 1, mfaInput );
+			authenticatedState = await oktaApi.AuthenticateChallengeMfaAsync( authState, selectedMfaIndex - 1, mfaInput );
 		} else if( authState.OktaSessionToken is not null ) {
 			authenticatedState = new OktaAuthenticatedState( true, authState.OktaSessionToken );
 		}

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -11,13 +11,13 @@ namespace D2L.Bmx.Okta;
 internal interface IOktaApi {
 	void SetOrganization( string organization );
 	void AddSession( string sessionId );
-	Task<OktaAuthenticateState> AuthenticateOktaAsync( AuthenticateOptions authOptions );
-	Task<OktaAuthenticatedState> AuthenticateChallengeMfaOktaAsync( OktaAuthenticateState state, int selectedMfaIndex,
+	Task<OktaAuthenticateState> AuthenticateAsync( AuthenticateOptions authOptions );
+	Task<OktaAuthenticatedState> AuthenticateChallengeMfaAsync( OktaAuthenticateState state, int selectedMfaIndex,
 		string challengeResponse );
-	Task IssueMfaChallengeOktaAsync( OktaAuthenticateState state, int selectedMfaIndex );
-	Task<OktaSession> CreateSessionOktaAsync( SessionOptions sessionOptions );
-	Task<OktaAccountState> GetAccountsOktaAsync( OktaAuthenticatedState state, string accountType );
-	Task<string> GetAccountOktaAsync( OktaAccountState state, string selectedAccount );
+	Task IssueMfaChallengeAsync( OktaAuthenticateState state, int selectedMfaIndex );
+	Task<OktaSession> CreateSessionAsync( SessionOptions sessionOptions );
+	Task<OktaAccountState> GetAccountsAsync( OktaAuthenticatedState state, string accountType );
+	Task<string> GetAccountAsync( OktaAccountState state, string selectedAccount );
 }
 
 internal class OktaApi : IOktaApi {
@@ -44,7 +44,7 @@ internal class OktaApi : IOktaApi {
 		}
 	}
 
-	async Task<OktaAuthenticateState> IOktaApi.AuthenticateOktaAsync( AuthenticateOptions authOptions ) {
+	async Task<OktaAuthenticateState> IOktaApi.AuthenticateAsync( AuthenticateOptions authOptions ) {
 
 		var resp = await _httpClient.PostAsync( "authn",
 			new StringContent(
@@ -63,7 +63,7 @@ internal class OktaApi : IOktaApi {
 		throw new BmxException( "Error authenticating Okta" );
 	}
 
-	async Task IOktaApi.IssueMfaChallengeOktaAsync( OktaAuthenticateState state, int selectedMfaIndex ) {
+	async Task IOktaApi.IssueMfaChallengeAsync( OktaAuthenticateState state, int selectedMfaIndex ) {
 		var mfaFactor = state.OktaMfaFactors[selectedMfaIndex];
 		var authOptions = new AuthenticateChallengeMfaOptions( FactorId: mfaFactor.Id, StateToken: state.OktaStateToken! );
 
@@ -74,7 +74,7 @@ internal class OktaApi : IOktaApi {
 				"application/json" ) );
 	}
 
-	async Task<OktaAuthenticatedState> IOktaApi.AuthenticateChallengeMfaOktaAsync(
+	async Task<OktaAuthenticatedState> IOktaApi.AuthenticateChallengeMfaAsync(
 		OktaAuthenticateState state, int selectedMfaIndex,
 		string challengeResponse ) {
 
@@ -98,7 +98,7 @@ internal class OktaApi : IOktaApi {
 		throw new BmxException( "Error authenticating Okta challenge MFA" );
 	}
 
-	async Task<OktaSession> IOktaApi.CreateSessionOktaAsync( SessionOptions sessionOptions ) {
+	async Task<OktaSession> IOktaApi.CreateSessionAsync( SessionOptions sessionOptions ) {
 		var resp = await _httpClient.PostAsync( "sessions",
 			new StringContent(
 				JsonSerializer.Serialize( sessionOptions, SourceGenerationContext.Default.SessionOptions ),
@@ -112,9 +112,9 @@ internal class OktaApi : IOktaApi {
 		throw new BmxException( "Error creating Okta session" );
 	}
 
-	async Task<OktaAccountState> IOktaApi.GetAccountsOktaAsync( OktaAuthenticatedState state, string accountType ) {
+	async Task<OktaAccountState> IOktaApi.GetAccountsAsync( OktaAuthenticatedState state, string accountType ) {
 		// TODO: Use existing session if it exists in ~/.bmx and isn't expired
-		var sessionResp = await ( this as IOktaApi ).CreateSessionOktaAsync( new SessionOptions( state.OktaSessionToken ) );
+		var sessionResp = await ( this as IOktaApi ).CreateSessionAsync( new SessionOptions( state.OktaSessionToken ) );
 		// TODO: Consider making OktaAPI stateless as well (?)
 		( this as IOktaApi ).AddSession( sessionResp.Id );
 
@@ -127,7 +127,7 @@ internal class OktaApi : IOktaApi {
 		throw new BmxException( "Error retrieving Okta accounts" );
 	}
 
-	async Task<string> IOktaApi.GetAccountOktaAsync( OktaAccountState state, string selectedAccount ) {
+	async Task<string> IOktaApi.GetAccountAsync( OktaAccountState state, string selectedAccount ) {
 
 		var account = Array.Find(
 			state.OktaApps,

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -47,7 +47,7 @@ internal class PrintHandler {
 		// Asks for user password input, or logs them in through caches
 		var authState = await Authenticator.AuthenticateAsync( org, user, nomask, _oktaApi );
 
-		var accountState = await _oktaApi.GetAccountsOktaAsync( authState, "amazon_aws" );
+		var accountState = await _oktaApi.GetAccountsAsync( authState, "amazon_aws" );
 		var accounts = accountState.Accounts;
 
 		if( string.IsNullOrEmpty( account ) ) {
@@ -58,7 +58,7 @@ internal class PrintHandler {
 			}
 		}
 
-		var accountCredentials = await _oktaApi.GetAccountOktaAsync( accountState, account );
+		var accountCredentials = await _oktaApi.GetAccountAsync( accountState, account );
 		var roleState = _awsClient.GetRoles( accountCredentials );
 		var roles = roleState.Roles;
 

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -47,7 +47,7 @@ internal class WriteHandler {
 		// Asks for user password input, or logs them in through caches
 		var authState = await Authenticator.AuthenticateAsync( org, user, nomask, _oktaApi );
 
-		var accountState = await _oktaApi.GetAccountsOktaAsync( authState, "amazon_aws" );
+		var accountState = await _oktaApi.GetAccountsAsync( authState, "amazon_aws" );
 		var accounts = accountState.Accounts;
 
 		if( string.IsNullOrEmpty( account ) ) {
@@ -58,7 +58,7 @@ internal class WriteHandler {
 			}
 		}
 
-		var accountCredentials = await _oktaApi.GetAccountOktaAsync( accountState, account );
+		var accountCredentials = await _oktaApi.GetAccountAsync( accountState, account );
 		var roleState = _awsClient.GetRoles( accountCredentials );
 		var roles = roleState.Roles;
 


### PR DESCRIPTION
### Why

Removes redundant naming of Okta API methods