### PR TITLE
cache okta sessions

### DIFF
--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -65,7 +65,7 @@ internal class Authenticator {
 			sessionToken = authState.OktaSessionToken;
 		}
 
-		if( !sessionToken.Equals( "" ) ) {
+		if( !string.IsNullOrEmpty( sessionToken ) ) {
 			var sessionResp = await oktaApi.CreateSessionOktaAsync( new SessionOptions( sessionToken ) );
 			oktaApi.AddSession( sessionResp.Id );
 			CacheOktaSession( user, org, sessionResp.Id, sessionResp.ExpiresAt );
@@ -81,13 +81,13 @@ internal class Authenticator {
 		IOktaApi oktaApi
 	) {
 		var sessionId = GetCachedOktaSession( user, org );
-		if( sessionId.Equals( "" ) ) {
+		if( string.IsNullOrEmpty( sessionId ) ) {
 			return new( false, "" );
 		}
 
 		oktaApi.AddSession( sessionId );
 		var userId = await oktaApi.GetMeResponseAsync( sessionId );
-		return new( !userId.Equals( "" ), sessionId );
+		return new( !string.IsNullOrEmpty( userId ), sessionId );
 	}
 
 	private static void CacheOktaSession( string userId, string org, string sessionId, DateTimeOffset expiresAt ) {

--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -104,7 +104,7 @@ internal class Authenticator {
 	private static string? GetCachedOktaSessionId( string userId, string org ) {
 		var oktaSessions = ReadOktaSessionCacheFile();
 		var session = oktaSessions.Find( session => session.UserId == userId && session.Org == org );
-		return session?.SessionId ?? null;
+		return session?.SessionId;
 	}
 
 	private static List<OktaSessionCache> ReadOktaSessionCacheFile() {

--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -105,15 +105,10 @@ internal class Authenticator {
 	}
 
 	private static List<OktaSessionCache> ReadOktaSessionCacheFile() {
-		var sessions = OktaSessionStorage.Sessions();
-		return RemoveExpiredOktaSessions( sessions );
-	}
-
-	private static List<OktaSessionCache> RemoveExpiredOktaSessions( List<OktaSessionCache> sourceCache ) {
+		var sourceCache = OktaSessionStorage.Sessions();
 		var currTime = DateTimeOffset.Now;
 		return sourceCache.Where( session => session.ExpiresAt > currTime ).ToList();
 	}
-
 
 	private static int PromptMfa( MfaOption[] mfaOptions ) {
 

--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -101,7 +101,7 @@ internal class Authenticator {
 		OktaSessionStorage.SaveSessions( existingSessions );
 	}
 
-	private static string GetCachedOktaSession( string userId, string org ) {
+	private static string? GetCachedOktaSessionId( string userId, string org ) {
 		var oktaSessions = ReadOktaSessionCacheFile();
 		var session = oktaSessions.Find( session => session.UserId == userId && session.Org == org );
 		return session?.SessionId ?? "";

--- a/src/D2L.Bmx/Authenticate.cs
+++ b/src/D2L.Bmx/Authenticate.cs
@@ -34,7 +34,7 @@ internal class Authenticator {
 			}
 		}
 
-		var authState = await oktaApi.AuthenticateOktaAsync( new AuthenticateOptions( user, password ) )
+		var authState = await oktaApi.AuthenticateAsync( new AuthenticateOptions( user, password ) )
 			.ConfigureAwait( false );
 
 		string? sessionToken = null;
@@ -65,7 +65,7 @@ internal class Authenticator {
 		}
 
 		if( !string.IsNullOrEmpty( sessionToken ) ) {
-			var sessionResp = await oktaApi.CreateSessionOktaAsync( new SessionOptions( sessionToken ) );
+			var sessionResp = await oktaApi.CreateSessionAsync( new SessionOptions( sessionToken ) );
 			// TODO: Consider making OktaAPI stateless as well (?)
 			oktaApi.AddSession( sessionResp.Id );
 			CacheOktaSession( user, org, sessionResp.Id, sessionResp.ExpiresAt );
@@ -80,7 +80,7 @@ internal class Authenticator {
 		string user,
 		IOktaApi oktaApi
 	) {
-		var sessionId = GetCachedOktaSession( user, org );
+		var sessionId = GetCachedOktaSessionId( user, org );
 		if( string.IsNullOrEmpty( sessionId ) ) {
 			return new( SuccessfulAuthentication: false, OktaSessionId: "" );
 		}
@@ -104,7 +104,7 @@ internal class Authenticator {
 	private static string? GetCachedOktaSessionId( string userId, string org ) {
 		var oktaSessions = ReadOktaSessionCacheFile();
 		var session = oktaSessions.Find( session => session.UserId == userId && session.Org == org );
-		return session?.SessionId ?? "";
+		return session?.SessionId ?? null;
 	}
 
 	private static List<OktaSessionCache> ReadOktaSessionCacheFile() {

--- a/src/D2L.Bmx/Okta/Models/OktaMeResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/OktaMeResponse.cs
@@ -1,0 +1,5 @@
+namespace D2L.Bmx.Okta.Models;
+
+internal record OktaMeResponse(
+	string Id
+);

--- a/src/D2L.Bmx/Okta/Models/OktaSessionCache.cs
+++ b/src/D2L.Bmx/Okta/Models/OktaSessionCache.cs
@@ -1,0 +1,7 @@
+namespace D2L.Bmx.Okta.Models;
+internal record OktaSessionCache(
+	string UserId,
+	string Org,
+	string SessionId,
+	DateTimeOffset ExpiresAt
+);

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -152,7 +152,7 @@ internal class OktaApi : IOktaApi {
 
 			var meJson = await meResponse.Content.ReadAsStringAsync();
 			var me = await meResponse.Content.ReadFromJsonAsync( SourceGenerationContext.Default.OktaMeResponse );
-			return me?.Id ?? null;
+			return me?.Id;
 		} catch( HttpRequestException ) {
 			return null;
 		} catch( JsonException ) {

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -40,10 +40,6 @@ internal class OktaApi : IOktaApi {
 		_httpClient.BaseAddress = new Uri( $"https://{organization}.okta.com/api/v1/" );
 	}
 
-	Uri IOktaApi.GetOrganizationUri() {
-		return _httpClient.BaseAddress!;
-	}
-
 	void IOktaApi.AddSession( string sessionId ) {
 		if( _httpClient.BaseAddress is not null ) {
 			_cookieContainer.Add( new Cookie( "sid", sessionId, "/", _httpClient.BaseAddress.Host ) );

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -1,12 +1,10 @@
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml;
-using Amazon.Runtime.Internal.Endpoints.StandardLibrary;
 using D2L.Bmx.Okta.Models;
 using D2L.Bmx.Okta.State;
 namespace D2L.Bmx.Okta;
@@ -15,12 +13,13 @@ internal interface IOktaApi {
 	void SetOrganization( string organization );
 	void AddSession( string sessionId );
 	Task<OktaAuthenticateState> AuthenticateAsync( AuthenticateOptions authOptions );
-	Task<OktaAuthenticatedState> AuthenticateChallengeMfaAsync( OktaAuthenticateState state, int selectedMfaIndex,
+	Task<string> AuthenticateChallengeMfaAsync( OktaAuthenticateState state, int selectedMfaIndex,
 		string challengeResponse );
 	Task IssueMfaChallengeAsync( OktaAuthenticateState state, int selectedMfaIndex );
 	Task<OktaSession> CreateSessionAsync( SessionOptions sessionOptions );
 	Task<OktaAccountState> GetAccountsAsync( OktaAuthenticatedState state, string accountType );
 	Task<string> GetAccountAsync( OktaAccountState state, string selectedAccount );
+	Task<string?> GetMeResponseAsync( string sessionId );
 }
 
 internal class OktaApi : IOktaApi {
@@ -77,7 +76,7 @@ internal class OktaApi : IOktaApi {
 				"application/json" ) );
 	}
 
-	async Task<OktaAuthenticatedState> IOktaApi.AuthenticateChallengeMfaAsync(
+	async Task<string> IOktaApi.AuthenticateChallengeMfaAsync(
 		OktaAuthenticateState state, int selectedMfaIndex,
 		string challengeResponse ) {
 

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -1,6 +1,6 @@
 using System.Net;
-using System.Net.Http.Json;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -13,7 +13,6 @@ namespace D2L.Bmx.Okta;
 internal interface IOktaApi {
 	void SetOrganization( string organization );
 	void AddSession( string sessionId );
-	Uri GetOrganizationUri();
 	Task<OktaAuthenticateState> AuthenticateOktaAsync( AuthenticateOptions authOptions );
 	Task<string> AuthenticateChallengeMfaOktaAsync( OktaAuthenticateState state, int selectedMfaIndex,
 		string challengeResponse );

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -146,8 +146,7 @@ internal class OktaApi : IOktaApi {
 	async Task<string> IOktaApi.GetMeResponseAsync( string sessionId ) {
 
 		try {
-			using var meRequest = new HttpRequestMessage( HttpMethod.Get, "users/me" );
-			using var meResponse = await _httpClient.SendAsync( meRequest );
+			using var meResponse = await _httpClient.GetAsync( "users/me" );
 
 			if( !meResponse.IsSuccessStatusCode ) {
 				return "";

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using D2L.Bmx.Okta.Models;
+
+namespace D2L.Bmx.Okta;
+
+[JsonSerializable( typeof( OktaSessionCache[] ) )]
+internal partial class OktaSessionContext : JsonSerializerContext {
+}
+
+internal class OktaSessionStorage {
+
+	internal static void SaveSessions( List<OktaSessionCache> sessions ) {
+
+		string jsonString = JsonSerializer.Serialize( sessions.ToArray(), OktaSessionContext.Default.OktaSessionCacheArray );
+		File.WriteAllText( SessionsFileName(), jsonString );
+	}
+
+	internal static List<OktaSessionCache> Sessions() {
+
+		var bmxDirectory = BmxDir();
+		var sessionsFileName = SessionsFileName();
+
+		if( !Directory.Exists( bmxDirectory ) ) {
+			Directory.CreateDirectory( bmxDirectory );
+		}
+
+		if( !File.Exists( sessionsFileName ) ) {
+			File.WriteAllText( sessionsFileName, "[]" );
+		}
+
+		try {
+			var sessionsJson = File.ReadAllText( SessionsFileName() );
+			var sessions = JsonSerializer.Deserialize( sessionsJson, OktaSessionContext.Default.OktaSessionCacheArray );
+			if( sessions is not null ) {
+				return sessions.ToList();
+			}
+		} catch( JsonException ) {
+			return new();
+		}
+		return new();
+	}
+
+	internal static string SessionsFileName() {
+		return Path.Join( UserHomeDir(), ".bmx3", "sessions" );
+	}
+
+	internal static string BmxDir() {
+		return Path.Join( UserHomeDir(), ".bmx3" );
+	}
+
+	internal static string UserHomeDir() {
+
+		string osPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
+		string pattern = @"(?i)\bwindows\b";
+
+		if( Regex.IsMatch( osPlatform, pattern ) ) {
+			string? home = Environment.GetEnvironmentVariable( "HOMEDRIVE" ) + Environment.GetEnvironmentVariable( "HOMEPATH" );
+			if( home is null || home.Equals( "" ) ) {
+				home = Environment.GetEnvironmentVariable( "USERPROFILE" );
+			}
+			return home!;
+		}
+		return Environment.GetEnvironmentVariable( "HOME" )!;
+	}
+}

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -49,16 +49,6 @@ internal class OktaSessionStorage {
 
 	internal static string UserHomeDir() {
 
-		string osPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-		string pattern = @"(?i)\bwindows\b";
-
-		if( Regex.IsMatch( osPlatform, pattern ) ) {
-			string? home = Environment.GetEnvironmentVariable( "HOMEDRIVE" ) + Environment.GetEnvironmentVariable( "HOMEPATH" );
-			if( home is null || home.Equals( "" ) ) {
-				home = Environment.GetEnvironmentVariable( "USERPROFILE" );
-			}
-			return home!;
-		}
-		return Environment.GetEnvironmentVariable( "HOME" )!;
+		return Environment.GetFolderPath( Environment.SpecialFolder.UserProfile );
 	}
 }

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -44,7 +44,7 @@ internal class OktaSessionStorage {
 	}
 
 	internal static string BmxDir() {
-		return Path.Join( UserHomeDir(), ".bmx3" );
+		return Path.Join( UserHomeDir(), ".bmx" );
 	}
 
 	internal static string UserHomeDir() {

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -40,7 +40,7 @@ internal class OktaSessionStorage {
 	}
 
 	internal static string SessionsFileName() {
-		return Path.Join( UserHomeDir(), ".bmx3", "sessions" );
+		return Path.Join( UserHomeDir(), ".bmx", "sessions" );
 	}
 
 	internal static string BmxDir() {

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using D2L.Bmx.Okta.Models;
 
 namespace D2L.Bmx.Okta;
@@ -9,8 +8,8 @@ internal class OktaSessionStorage {
 	internal static void SaveSessions( List<OktaSessionCache> sessions ) {
 
 		string jsonString = JsonSerializer.Serialize(
-			sessions.ToArray(),
-			SourceGenerationContext.Default.OktaSessionCacheArray );
+			sessions,
+			SourceGenerationContext.Default.ListOktaSessionCache );
 		File.WriteAllText( SessionsFileName(), jsonString );
 	}
 
@@ -29,9 +28,9 @@ internal class OktaSessionStorage {
 
 		try {
 			var sessionsJson = File.ReadAllText( SessionsFileName() );
-			var sessions = JsonSerializer.Deserialize( sessionsJson, SourceGenerationContext.Default.OktaSessionCacheArray );
+			var sessions = JsonSerializer.Deserialize( sessionsJson, SourceGenerationContext.Default.ListOktaSessionCache );
 			if( sessions is not null ) {
-				return sessions.ToList();
+				return sessions;
 			}
 		} catch( JsonException ) {
 			return new();

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -1,19 +1,16 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using D2L.Bmx.Okta.Models;
 
 namespace D2L.Bmx.Okta;
 
-[JsonSerializable( typeof( OktaSessionCache[] ) )]
-internal partial class OktaSessionContext : JsonSerializerContext {
-}
-
 internal class OktaSessionStorage {
 
 	internal static void SaveSessions( List<OktaSessionCache> sessions ) {
 
-		string jsonString = JsonSerializer.Serialize( sessions.ToArray(), OktaSessionContext.Default.OktaSessionCacheArray );
+		string jsonString = JsonSerializer.Serialize(
+			sessions.ToArray(),
+			SourceGenerationContext.Default.OktaSessionCacheArray );
 		File.WriteAllText( SessionsFileName(), jsonString );
 	}
 
@@ -32,7 +29,7 @@ internal class OktaSessionStorage {
 
 		try {
 			var sessionsJson = File.ReadAllText( SessionsFileName() );
-			var sessions = JsonSerializer.Deserialize( sessionsJson, OktaSessionContext.Default.OktaSessionCacheArray );
+			var sessions = JsonSerializer.Deserialize( sessionsJson, SourceGenerationContext.Default.OktaSessionCacheArray );
 			if( sessions is not null ) {
 				return sessions.ToList();
 			}

--- a/src/D2L.Bmx/Okta/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/Okta/SourceGenerationContext.cs
@@ -10,5 +10,6 @@ namespace D2L.Bmx.Okta;
 [JsonSerializable( typeof( AuthenticateResponseSuccess ) )]
 [JsonSerializable( typeof( OktaSession ) )]
 [JsonSerializable( typeof( OktaApp[] ) )]
+[JsonSerializable( typeof( OktaMeResponse ) )]
 internal partial class SourceGenerationContext : JsonSerializerContext {
 }

--- a/src/D2L.Bmx/Okta/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/Okta/SourceGenerationContext.cs
@@ -11,6 +11,6 @@ namespace D2L.Bmx.Okta;
 [JsonSerializable( typeof( OktaSession ) )]
 [JsonSerializable( typeof( OktaApp[] ) )]
 [JsonSerializable( typeof( OktaMeResponse ) )]
-[JsonSerializable( typeof( OktaSessionCache[] ) )]
+[JsonSerializable( typeof( List<OktaSessionCache> ) )]
 internal partial class SourceGenerationContext : JsonSerializerContext {
 }

--- a/src/D2L.Bmx/Okta/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/Okta/SourceGenerationContext.cs
@@ -11,5 +11,6 @@ namespace D2L.Bmx.Okta;
 [JsonSerializable( typeof( OktaSession ) )]
 [JsonSerializable( typeof( OktaApp[] ) )]
 [JsonSerializable( typeof( OktaMeResponse ) )]
+[JsonSerializable( typeof( OktaSessionCache[] ) )]
 internal partial class SourceGenerationContext : JsonSerializerContext {
 }

--- a/src/D2L.Bmx/Okta/State/OktaAuthenticatedState.cs
+++ b/src/D2L.Bmx/Okta/State/OktaAuthenticatedState.cs
@@ -2,5 +2,5 @@ namespace D2L.Bmx.Okta.State;
 
 internal record OktaAuthenticatedState(
 	bool SuccessfulAuthentication,
-	string OktaSessionToken
+	string OktaSessionId
 );


### PR DESCRIPTION
### Why

Currently we need to type our okta password in every time. Go version supported caching a session id and reusing it until expiry


Related trello card: https://trello.com/c/GGgGonzC/1216-support-storing-session-and-profiles