### PR TITLE
Ci/rename linux builds

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,0 +1,32 @@
+name: "create release"
+description: "Creates a new GitHub release with incremented version"
+inputs:
+  version:
+    description: 'Version number for the new release'
+    required: false
+    default: '3.0.0'
+outputs:
+  release_tag:
+    description: "The tag of the created release"
+    value: ${{ steps.create_release.outputs.release_tag }}
+runs:
+  using: "composite"
+  steps:
+    - name: checkout
+      uses: Brightspace/third-party-actions@actions/checkout
+    - run: sudo apt-get update && sudo apt-get install -y jq bc
+      shell: bash
+    - name: create release
+      id: create_release
+      run: |
+        $version = "${{ inputs.version }}"
+
+        $RELEASE_TAG = "v$version"
+        echo "RELEASE_TAG=$RELEASE_TAG" >> GITHUB_OUTPUT
+
+        gh release create "$RELEASE_TAG" `
+          --title "Release $RELEASE_TAG" `
+          --notes "Release notes for version $RELEASE_TAG"
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,9 +79,9 @@ jobs:
       matrix:
         include:
           - file: Dockerfile.ubuntu
-            platform: ubuntu
+            platform: linux
           - file: Dockerfile.alpine
-            platform: alpine
+            platform: linux.alpine
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
### Why

The ubuntu version works for other linux distros. Alpine is just the one off where it needs a separate build