### PR TITLE
longer docker builds timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
           - file: Dockerfile.alpine
             platform: linux.alpine
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: checkout
         uses: Brightspace/third-party-actions@actions/checkout


### PR DESCRIPTION
Seeing some Docker builds timeout. Looks like ubuntu.com may be slow today.
https://github.com/Brightspace/bmx/actions/runs/4982545341/jobs/8918545588

No reason to give a shorter 5-minute timeout to the Docker builds when the non-containerized builds have a timeout of 10 minutes.