### PR TITLE
ci: publish workflow uses draft tag id and finalizes release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      ${{ !failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+      ${{ !failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,23 +11,28 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/publish.yml"
-  repository_dispatch:
-    types: [create-release]
-    client_payload:
+  workflow_dispatch:
+    inputs:
       release_tag:
         required: true
+        description: 'Tag for the new release'
 
 jobs:
   create_release:
-    if: github.event_name == 'repository_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
     steps:
       - name: Create release
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
           GH_TOKEN: ${{ github.token }}
+        shell: pwsh
         run: |
-          gh release create "$RELEASE_TAG" --draft --generate-notes --title "Release $RELEASE_TAG"
+          $releaseUrl = gh release create "$RELEASE_TAG" --draft --generate-notes --title "Release $RELEASE_TAG"
+          $releaseId = $releaseUrl -split '/' | Select-Object -Last 1
+          Write-Output "::set-output name=release_id::$releaseId"
 
   build:
     needs: create_release
@@ -54,10 +59,10 @@ jobs:
         run: |
           dotnet publish -r $env:PLATFORM-x64 -c Release -o build
       - name: upload build
-        if: github.event_name == 'repository_dispatch'
+        if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          RELEASE_TAG: ${{ needs.create_release.outputs.release_id }}
           PLATFORM: ${{ matrix.platform }}
           FILE_NAME: ${{ matrix.file_name }}
           GH_TOKEN: ${{ github.token }}
@@ -96,10 +101,10 @@ jobs:
         run: |
           docker buildx build -f $env:DOCKERFILE -o build .
       - name: upload build
-        if: github.event_name == 'repository_dispatch'
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          RELEASE_TAG: ${{ needs.create_release.outputs.release_id }}
           PLATFORM: ${{ matrix.platform }}
           GH_TOKEN: ${{ github.token }}
         working-directory: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       release_id: ${{ steps.create.outputs.release_id }}
     steps:
       - name: Create release
+        id: create
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
           PRERELEASE: ${{ github.events.input.prerelease }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,12 @@ on:
       release_tag:
         required: true
         description: 'Tag for the new release'
+    dry_run:
+      description: 'If true, the draft release will not be finalized'
+      type: boolean
+      required: true
+      default: false
+
 
 jobs:
   create_release:
@@ -112,3 +118,18 @@ jobs:
           chmod +x "bmx"
           tar -czvf "bmx-$PLATFORM.tar.gz" "bmx"
           gh release upload "$RELEASE_TAG" "bmx-$PLATFORM.tar.gz"
+
+  publish_release:
+    needs: [create_release, build, build_docker]
+    if: |
+      ${{ !failure() && github.event_name == 'workflow_dispatch' `
+        && github.event.inputs.dry_run == 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      RELEASE_TAG: ${{ needs.create_release.outputs.release_id }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: finalize release
+        run: |
+          gh release update "$env:RELEASE_ID" --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          $prereleaseFlag = if ($env:PRERELEASE -eq $true) { '--prerelease' } else { '' }
-          $releaseUrl = gh release create "$env:RELEASE_TAG" $prereleaseFlag --draft --generate-notes --title "Release $env:RELEASE_TAG"
+          if ($env:PRERELEASE -eq 'true') {
+              $releaseUrl = gh release create "$env:RELEASE_TAG" --draft --prerelease --generate-notes --title "Release $env:RELEASE_TAG"
+          } else {
+              $releaseUrl = gh release create "$env:RELEASE_TAG" --draft --generate-notes --title "Release $env:RELEASE_TAG"
+          }
           if ( $LASTEXITCODE -ne 0 ) { throw "Failed to create draft release" }
 
           $releaseId = $releaseUrl -split '/' | Select-Object -Last 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      ${{ !failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false }}
+      ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          $releaseUrl = gh release create "$RELEASE_TAG" --draft --generate-notes --title "Release $RELEASE_TAG"
+          $releaseUrl = gh release create "$env:RELEASE_TAG" --draft --generate-notes --title "Release $env:RELEASE_TAG"
+          if ( $LASTEXITCODE -ne 0 ) { throw "Failed to create draft release" }
+
           $releaseId = $releaseUrl -split '/' | Select-Object -Last 1
-          Write-Output "::set-output name=release_id::$releaseId"
+          "release_id=$releaseId" >> $env:GITHUB_OUTPUT
 
   build:
     needs: create_release
@@ -131,5 +133,5 @@ jobs:
     steps:
       - name: finalize release
         run: |
-          # gh release edit "$env:RELEASE_ID" --draft=false
+          # gh release edit "$RELEASE_ID" --draft=false
           echo ":)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,8 +126,6 @@ jobs:
 
   publish_release:
     needs: [create_release, build, build_docker]
-    if: |
-      github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   create_release:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
@@ -124,7 +124,8 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false }}
+      github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false
+      && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,4 +137,4 @@ jobs:
     steps:
       - name: finalize release
         run: |
-           gh release edit "$RELEASE_ID" --draft=false
+          gh release edit "$RELEASE_ID" --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   create_release:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || github.events.input.prerelease == 'true')
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ on:
       release_tag:
         required: true
         description: 'Tag for the new release'
-    dry_run:
-      description: 'If true, the draft release will not be finalized'
+    prerelease:
+      description: 'If true, the release will be set as a prerelease and not impact the latest tag'
       type: boolean
       required: true
       default: false
@@ -33,10 +33,12 @@ jobs:
       - name: Create release
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          PRERELEASE: ${{ github.events.input.prerelease }}
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          $releaseUrl = gh release create "$env:RELEASE_TAG" --draft --generate-notes --title "Release $env:RELEASE_TAG"
+          $prereleaseFlag = if ($env:PRERELEASE -eq $true) { '--prerelease' } else { '' }
+          $releaseUrl = gh release create "$env:RELEASE_TAG" $prereleaseFlag --draft --generate-notes --title "Release $env:RELEASE_TAG"
           if ( $LASTEXITCODE -ne 0 ) { throw "Failed to create draft release" }
 
           $releaseId = $releaseUrl -split '/' | Select-Object -Last 1
@@ -124,8 +126,7 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == false
-      && github.ref == 'refs/heads/main'
+      github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      ${{ !failure() && github.event_name == 'workflow_dispatch' `
+      ${{ !failure() && github.event_name == 'workflow_dispatch'
         && github.event.inputs.dry_run == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,8 +122,7 @@ jobs:
   publish_release:
     needs: [create_release, build, build_docker]
     if: |
-      ${{ !failure() && github.event_name == 'workflow_dispatch'
-        && github.event.inputs.dry_run == 'false' }}
+      ${{ !failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -132,4 +131,5 @@ jobs:
     steps:
       - name: finalize release
         run: |
-          gh release update "$env:RELEASE_ID" --draft=false
+          # gh release edit "$env:RELEASE_ID" --draft=false
+          echo ":)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,5 +137,4 @@ jobs:
     steps:
       - name: finalize release
         run: |
-          # gh release edit "$RELEASE_ID" --draft=false
-          echo ":)"
+           gh release edit "$RELEASE_ID" --draft=false


### PR DESCRIPTION
### Why

Creating a drafted release doesn't set the tag as what our input is. It's of some format untagged-xxxxxxxxxx . So we need to extract that value from when we create the release and then pass that to remaining steps when uploading.

Also need a new step for removing the draft flag once all the builds have been uploaded.
We're adding a new input for the dispatch called `prerelease`. This will set the created release as a prerelease so we can test the entire workflow without updating the `latest` release tag