### PR TITLE
ci: publish indent prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ on:
       release_tag:
         required: true
         description: 'Tag for the new release'
-    prerelease:
-      description: 'If true, the release will be set as a prerelease and not impact the latest tag'
-      type: boolean
-      required: true
-      default: false
+      prerelease:
+        description: 'If true, the release will be set as a prerelease and not impact the latest tag'
+        type: boolean
+        required: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,12 @@ on:
     inputs:
       release_tag:
         required: true
-        description: 'Tag for the new release'
+        description: "Tag for the new release"
       prerelease:
-        description: 'If true, the release will be set as a prerelease and not impact the latest tag'
+        description: "If true, the release will be set as a prerelease and not impact the latest tag"
         type: boolean
         required: true
         default: false
-
 
 jobs:
   create_release:


### PR DESCRIPTION
### Why

The prerelease input was one tab off and not under `inputs`. Oops