### PR TITLE
make classes non-static where appropriate

### DIFF
--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -18,11 +18,11 @@ internal class ConfigureHandler {
 
 		if( string.IsNullOrEmpty( org ) ) {
 			org = _consolePrompter.PromptOrg();
-		};
+		}
 
 		if( string.IsNullOrEmpty( user ) ) {
 			user = _consolePrompter.PromptUser();
-		};
+		}
 
 		if( defaultDuration is null ) {
 			defaultDuration = _consolePrompter.PromptDefaultDuration();

--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -3,9 +3,11 @@ namespace D2L.Bmx;
 internal class ConfigureHandler {
 
 	private readonly IBmxConfigProvider _configProvider;
+	private readonly IConsolePrompter _consolePrompter;
 
-	public ConfigureHandler( IBmxConfigProvider configProvider ) {
+	public ConfigureHandler( IBmxConfigProvider configProvider, IConsolePrompter consolePrompter ) {
 		_configProvider = configProvider;
+		_consolePrompter = consolePrompter;
 	}
 
 	public void Handle(
@@ -15,15 +17,15 @@ internal class ConfigureHandler {
 	) {
 
 		if( string.IsNullOrEmpty( org ) ) {
-			org = ConsolePrompter.PromptOrg();
+			org = _consolePrompter.PromptOrg();
 		};
 
 		if( string.IsNullOrEmpty( user ) ) {
-			user = ConsolePrompter.PromptUser();
+			user = _consolePrompter.PromptUser();
 		};
 
 		if( defaultDuration is null ) {
-			defaultDuration = ConsolePrompter.PromptDefaultDuration();
+			defaultDuration = _consolePrompter.PromptDefaultDuration();
 		}
 
 		BmxConfig config = new(

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -50,7 +50,6 @@ internal class ConsolePrompter : IConsolePrompter {
 		Console.Error.Write( "Okta Password: " );
 		string password = "";
 
-		// TODO: remove nomask
 		while( true ) {
 			var input = Console.ReadKey( intercept: true );
 			if( input.Key == ConsoleKey.Enter ) {

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -1,9 +1,23 @@
+using D2L.Bmx.Okta.Models;
+
 namespace D2L.Bmx;
 
-internal static class ConsolePrompter {
+internal interface IConsolePrompter {
+	string PromptOrg();
+	string PromptProfile();
+	string PromptUser();
+	string PromptPassword();
+	int? PromptDefaultDuration();
+	string PromptAccount( string[] accounts );
+	string PromptRole( string[] roles );
+	int PromptMfa( MfaOption[] mfaOptions );
+	string PromptMfaInput( string mfaInputPrompt );
+}
 
-	public static string PromptOrg() {
-		Console.Write( "Okta org: " );
+internal class ConsolePrompter : IConsolePrompter {
+
+	string IConsolePrompter.PromptOrg() {
+		Console.Error.Write( "Okta org: " );
 		string? org = Console.ReadLine();
 		if( string.IsNullOrEmpty( org ) ) {
 			throw new BmxException( "Invalid org input" );
@@ -12,8 +26,8 @@ internal static class ConsolePrompter {
 		return org;
 	}
 
-	public static string PromptProfile() {
-		Console.Write( "AWS profile: " );
+	string IConsolePrompter.PromptProfile() {
+		Console.Error.Write( "AWS profile: " );
 		string? profile = Console.ReadLine();
 		if( string.IsNullOrEmpty( profile ) ) {
 			throw new BmxException( "Invalid profile input" );
@@ -22,8 +36,8 @@ internal static class ConsolePrompter {
 		return profile;
 	}
 
-	public static string PromptUser() {
-		Console.Write( "Okta Username: " );
+	string IConsolePrompter.PromptUser() {
+		Console.Error.Write( "Okta Username: " );
 		string? user = Console.ReadLine();
 		if( string.IsNullOrEmpty( user ) ) {
 			throw new BmxException( "Invalid user input" );
@@ -32,8 +46,27 @@ internal static class ConsolePrompter {
 		return user;
 	}
 
-	public static int? PromptDefaultDuration() {
-		Console.Write( "Default duration of session in minutes (optional, default: 60): " );
+	string IConsolePrompter.PromptPassword() {
+		Console.Error.Write( "Okta Password: " );
+		string password = "";
+
+		// TODO: remove nomask
+		while( true ) {
+			var input = Console.ReadKey( intercept: true );
+			if( input.Key == ConsoleKey.Enter ) {
+				Console.Error.Write( '\n' );
+				break;
+			} else if( input.Key == ConsoleKey.Backspace && password.Length > 0 ) {
+				password = password.Remove( password.Length - 1, 1 );
+			} else if( !char.IsControl( input.KeyChar ) ) {
+				password += input.KeyChar;
+			}
+		}
+		return password;
+	}
+
+	int? IConsolePrompter.PromptDefaultDuration() {
+		Console.Error.Write( "Default duration of session in minutes (optional, default: 60): " );
 		string? input = Console.ReadLine();
 		if( input is null || !int.TryParse( input, out int defaultDuration ) || defaultDuration <= 0 ) {
 			return null;
@@ -42,12 +75,12 @@ internal static class ConsolePrompter {
 		return defaultDuration;
 	}
 
-	public static string PromptAccount( string[] accounts ) {
-		Console.WriteLine( "Available accounts:" );
+	string IConsolePrompter.PromptAccount( string[] accounts ) {
+		Console.Error.WriteLine( "Available accounts:" );
 		for( int i = 0; i < accounts.Length; i++ ) {
-			Console.WriteLine( $"[{i + 1}] {accounts[i]}" );
+			Console.Error.WriteLine( $"[{i + 1}] {accounts[i]}" );
 		}
-		Console.Write( "Select an account: " );
+		Console.Error.Write( "Select an account: " );
 		if( !int.TryParse( Console.ReadLine(), out int index ) || index > accounts.Length || index < 1 ) {
 			throw new BmxException( "Invalid account selection" );
 		}
@@ -55,16 +88,46 @@ internal static class ConsolePrompter {
 		return accounts[index - 1];
 	}
 
-	public static string PromptRole( string[] roles ) {
-		Console.WriteLine( "Available roles:" );
+	string IConsolePrompter.PromptRole( string[] roles ) {
+		Console.Error.WriteLine( "Available roles:" );
 		for( int i = 0; i < roles.Length; i++ ) {
-			Console.WriteLine( $"[{i + 1}] {roles[i]}" );
+			Console.Error.WriteLine( $"[{i + 1}] {roles[i]}" );
 		}
-		Console.Write( "Select a role: " );
+		Console.Error.Write( "Select a role: " );
 		if( !int.TryParse( Console.ReadLine(), out int index ) || index > roles.Length || index < 1 ) {
 			throw new BmxException( "Invalid role selection" );
 		}
 
 		return roles[index - 1];
+	}
+
+	int IConsolePrompter.PromptMfa( MfaOption[] mfaOptions ) {
+		Console.Error.WriteLine( "MFA Required" );
+		if( mfaOptions.Length > 1 ) {
+			for( int i = 0; i < mfaOptions.Length; i++ ) {
+				Console.Error.WriteLine( $"[{i + 1}] {mfaOptions[i].Provider}: {mfaOptions[i].Name}" );
+			}
+			Console.Error.Write( "Select an available MFA option: " );
+			if( !int.TryParse( Console.ReadLine(), out int index ) || index > mfaOptions.Length || index < 1 ) {
+				throw new BmxException( "Invalid account selection" );
+			}
+			return index;
+		} else if( mfaOptions.Length == 0 ) {//idk, is mfaOptions' length guaranteed to be >= 1?
+			throw new BmxException( "No MFA method have been set up for the current user." );
+		} else {
+			Console.Error.WriteLine( $"MFA method: {mfaOptions[0].Provider}: {mfaOptions[0].Name}" );
+			return 1;
+		}
+
+	}
+
+	string IConsolePrompter.PromptMfaInput( string mfaInputPrompt ) {
+		Console.Error.Write( $"{mfaInputPrompt}: " );
+		string? mfaInput = Console.ReadLine();
+
+		if( mfaInput is not null ) {
+			return mfaInput;
+		}
+		throw new BmxException( "Invalid Mfa Input" );
 	}
 }

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using D2L.Bmx.Okta.Models;
 using D2L.Bmx.Okta.State;
+
 namespace D2L.Bmx.Okta;
 
 internal interface IOktaApi {

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -3,9 +3,13 @@ using D2L.Bmx.Okta.Models;
 
 namespace D2L.Bmx.Okta;
 
-internal class OktaSessionStorage {
+internal interface IOktaSessionStorage {
+	void SaveSessions( List<OktaSessionCache> sessions );
+	List<OktaSessionCache> Sessions();
+}
 
-	internal static void SaveSessions( List<OktaSessionCache> sessions ) {
+internal class OktaSessionStorage : IOktaSessionStorage {
+	void IOktaSessionStorage.SaveSessions( List<OktaSessionCache> sessions ) {
 
 		string jsonString = JsonSerializer.Serialize(
 			sessions,
@@ -13,7 +17,7 @@ internal class OktaSessionStorage {
 		File.WriteAllText( BmxPaths.SESSIONS_FILE_NAME, jsonString );
 	}
 
-	internal static List<OktaSessionCache> Sessions() {
+	List<OktaSessionCache> IOktaSessionStorage.Sessions() {
 
 		string bmxDirectory = BmxPaths.BMX_DIR;
 		string sessionsFileName = BmxPaths.SESSIONS_FILE_NAME;

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -46,7 +46,7 @@ internal class PrintHandler {
 			} else {
 				throw new BmxException( "Org value was not provided" );
 			}
-		};
+		}
 
 		// ask user to input username if user flag isn't set
 		if( string.IsNullOrEmpty( user ) ) {
@@ -57,7 +57,7 @@ internal class PrintHandler {
 			} else {
 				throw new BmxException( "User value was not provided" );
 			}
-		};
+		}
 
 		// Asks for user password input, or logs them in through caches
 		var authState = await _oktaAuthenticator.AuthenticateAsync( org, user, nonInteractive, _oktaApi );

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -43,7 +43,7 @@ internal class WriteHandler {
 			} else {
 				org = _consolePrompter.PromptOrg();
 			}
-		};
+		}
 
 		// ask user to input username if user flag isn't set
 		if( string.IsNullOrEmpty( user ) ) {
@@ -52,7 +52,7 @@ internal class WriteHandler {
 			} else {
 				user = _consolePrompter.PromptUser();
 			}
-		};
+		}
 
 		// Asks for user password input, or logs them in through caches
 		var authState = await _oktaAuthenticator.AuthenticateAsync( org, user, nonInteractive: false, _oktaApi );


### PR DESCRIPTION
### Why

Code that directly interacts with external systems should generally be put behind interfaces and not be in static classes/methods. This is necessary to have any sort of unit tests. The .NET bmx doesn't have unit tests right now, but we should still follow this general principle as a best practice.

Main changes:

* Consolidate all user console prompts into `ConsolePrompter` and put it behind an interface.
* Write all console prompts to stderr instead of stdout to make `bmx print` usable.
* Put `OktaSessionStorage` behind an interface too
* Rename `Authenticator` to `OktaAuthenticator` and move it to the Okta namespace

Note: I'm not putting all classes behind interfaces (e.g. `OktaAuthenticator`). Even when we want to unit test the code, code that doesn't directly interact with external systems doesn't necessarily need to be mocked. We can introduce interfaces when/if such a need arises.