### PR TITLE
consolidate code shared between print & write commands

### DIFF
--- a/src/D2L.Bmx/AwsCredsCreator.cs
+++ b/src/D2L.Bmx/AwsCredsCreator.cs
@@ -1,0 +1,65 @@
+using D2L.Bmx.Aws;
+using D2L.Bmx.Okta;
+
+namespace D2L.Bmx;
+
+internal class AwsCredsCreator {
+	private readonly IAwsClient _awsClient;
+	private readonly IConsolePrompter _consolePrompter;
+	private readonly BmxConfig _config;
+
+	public AwsCredsCreator(
+		IAwsClient awsClient,
+		IConsolePrompter consolePrompter,
+		BmxConfig config
+	) {
+		_awsClient = awsClient;
+		_consolePrompter = consolePrompter;
+		_config = config;
+	}
+
+	public async Task<AwsCredentials> CreateAwsCredsAsync(
+		IOktaApi oktaApi,
+		string? account,
+		string? role,
+		int? duration,
+		bool nonInteractive
+	) {
+		var accountState = await oktaApi.GetAccountsAsync( "amazon_aws" );
+		string[] accounts = accountState.Accounts;
+
+		if( string.IsNullOrEmpty( account ) ) {
+			if( !string.IsNullOrEmpty( _config.Account ) ) {
+				account = _config.Account;
+			} else if( !nonInteractive ) {
+				account = _consolePrompter.PromptAccount( accounts );
+			} else {
+				throw new BmxException( "Account value was not provided" );
+			}
+		}
+
+		string accountCredentials = await oktaApi.GetAccountAsync( accountState, account );
+		var roleState = _awsClient.GetRoles( accountCredentials );
+		string[] roles = roleState.Roles;
+
+		if( string.IsNullOrEmpty( role ) ) {
+			if( !string.IsNullOrEmpty( _config.Role ) ) {
+				role = _config.Role;
+			} else if( !nonInteractive ) {
+				role = _consolePrompter.PromptRole( roles );
+			} else {
+				throw new BmxException( "Role value was not provided" );
+			}
+		}
+
+		if( duration is null or 0 ) {
+			if( _config.DefaultDuration is not ( null or 0 ) ) {
+				duration = _config.DefaultDuration;
+			} else {
+				duration = 60;
+			}
+		}
+
+		return await _awsClient.GetTokensAsync( roleState, role, duration.Value );
+	}
+}

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -18,7 +18,7 @@ internal interface IOktaApi {
 		string challengeResponse );
 	Task IssueMfaChallengeAsync( OktaAuthenticateState state, int selectedMfaIndex );
 	Task<OktaSession> CreateSessionAsync( SessionOptions sessionOptions );
-	Task<OktaAccountState> GetAccountsAsync( OktaAuthenticatedState state, string accountType );
+	Task<OktaAccountState> GetAccountsAsync( string accountType );
 	Task<string> GetAccountAsync( OktaAccountState state, string selectedAccount );
 	Task<string?> GetMeResponseAsync( string sessionId );
 }
@@ -115,7 +115,7 @@ internal class OktaApi : IOktaApi {
 		throw new BmxException( "Error creating Okta session" );
 	}
 
-	async Task<OktaAccountState> IOktaApi.GetAccountsAsync( OktaAuthenticatedState state, string accountType ) {
+	async Task<OktaAccountState> IOktaApi.GetAccountsAsync( string accountType ) {
 		var resp = await _httpClient.GetAsync(
 			"users/me/appLinks" );
 


### PR DESCRIPTION
### Why

The print and write commands are identical for the most part except their final outputs, so it makes sense to consolidate their code too.

The process is split into three parts
1. authenticate to Okta (now all put in `OktaAuthenticator.AuthenticateAsync`)
2. use Okta session to obtain AWS creds (now all put in `AwsCredsCreator.CreateAwsCredsAsync`)
3. output the AWS creds (remain separate in print & write command handlers)

Step 1 can also be utilized/reused by the future `bmx login` command we talked about.

This also makes some future refactoring I'd like to do easier.