### PR TITLE
configure: create .bmx folder and config file if needed

### DIFF
--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -56,15 +56,8 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 
 	public void SaveConfiguration( BmxConfig config ) {
 
-		string bmxDirectory = BmxPaths.BMX_DIR;
-		string configFileName = BmxPaths.CONFIG_FILE_NAME;
-
-		if( !Directory.Exists( bmxDirectory ) ) {
-			Directory.CreateDirectory( bmxDirectory );
-		}
-
-		if( !File.Exists( configFileName ) ) {
-			File.WriteAllText( configFileName, "" );
+		if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
+			Directory.CreateDirectory( BmxPaths.BMX_DIR );
 		}
 
 		using var writer = new StreamWriter( BmxPaths.CONFIG_FILE_NAME, append: false );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -55,6 +55,18 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 	}
 
 	public void SaveConfiguration( BmxConfig config ) {
+
+		string bmxDirectory = BmxPaths.BMX_DIR;
+		string configFileName = BmxPaths.CONFIG_FILE_NAME;
+
+		if( !Directory.Exists( bmxDirectory ) ) {
+			Directory.CreateDirectory( bmxDirectory );
+		}
+
+		if( !File.Exists( configFileName ) ) {
+			File.WriteAllText( configFileName, "[]" );
+		}
+
 		using var writer = new StreamWriter( BmxPaths.CONFIG_FILE_NAME, append: false );
 
 		if( !string.IsNullOrEmpty( config.Org ) ) {

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -64,7 +64,7 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 		}
 
 		if( !File.Exists( configFileName ) ) {
-			File.WriteAllText( configFileName, "[]" );
+			File.WriteAllText( configFileName, "" );
 		}
 
 		using var writer = new StreamWriter( BmxPaths.CONFIG_FILE_NAME, append: false );


### PR DESCRIPTION
### Why

First time users will crash on finishing `bmx configure` command because the .bmx folder and config file does not exist