### PR TITLE
specify project path when building inside Docker

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,7 +13,7 @@ RUN wget https://dot.net/v1/dotnet-install.sh \
 WORKDIR /source
 
 COPY . .
-RUN dotnet publish -c release -r linux-musl-x64 -o app
+RUN dotnet publish src/D2L.Bmx -c release -r linux-musl-x64 -o app
 
 FROM scratch as export
 COPY --from=build /source/app /

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -13,7 +13,7 @@ RUN apt-get update \
 WORKDIR /source
 
 COPY . .
-RUN dotnet publish -c release -r linux-x64 -o app
+RUN dotnet publish src/D2L.Bmx -c release -r linux-x64 -o app
 
 FROM scratch as export
 COPY --from=build /source/app /


### PR DESCRIPTION
The SDK is complaining
https://github.com/Brightspace/bmx/actions/runs/5061042812/jobs/9086405178?pr=307#step:4:521

We can't output a solution because it may contain multiple projects. It isn't currently erroring because there's only one project in the solution, but it will once we add another project (e.g. tests).