### PR TITLE
update build configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,10 @@ jobs:
     steps:
       - name: checkout
         uses: Brightspace/third-party-actions@actions/checkout
+      - name: set up .NET
+        uses: Brightspace/third-party-actions@actions/setup-dotnet
+        with:
+          dotnet-version: 7.0.x
       - name: publish
         shell: pwsh
         working-directory: src/D2L.Bmx

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,8 +1,7 @@
 FROM amd64/alpine:3.15 AS build
 
 RUN apk update \
-    && apk add clang build-base bash icu-libs krb5-libs \
-    libgcc libintl libssl1.1 libstdc++ zlib zlib-dev
+    && apk add clang build-base bash zlib-dev
 
 RUN mkdir -p /usr/share/dotnet && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
@@ -11,6 +10,10 @@ RUN wget https://dot.net/v1/dotnet-install.sh \
     && ./dotnet-install.sh --channel 7.0 --install-dir /usr/share/dotnet
 
 WORKDIR /source
+
+# we have InvariantGlobalization=true in csproj file, so this shouldn't be necessary,
+# but the build still blows up without this env var ¯\_(ツ)_/¯
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 COPY . .
 RUN dotnet publish src/D2L.Bmx -c release -r linux-musl-x64 -o app

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,16 +1,19 @@
 FROM ubuntu:18.04 AS build
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates
-RUN wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
-    --no-check-certificate -O packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN rm packages-microsoft-prod.deb
-
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       dotnet-sdk-7.0 clang zlib1g-dev
+    && apt-get install -y --no-install-recommends wget ca-certificates clang zlib1g-dev
+
+RUN mkdir -p /usr/share/dotnet && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+RUN wget https://dot.net/v1/dotnet-install.sh \
+    && chmod +x ./dotnet-install.sh \
+    && ./dotnet-install.sh --channel 7.0 --install-dir /usr/share/dotnet
 
 WORKDIR /source
+
+# we have InvariantGlobalization=true in csproj file, so this shouldn't be necessary,
+# but the build still blows up without this env var ¯\_(ツ)_/¯
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 COPY . .
 RUN dotnet publish src/D2L.Bmx -c release -r linux-x64 -o app

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -5,20 +5,19 @@
     <PublishAot>true</PublishAot>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <RootNamespace>D2L.Bmx</RootNamespace>
     <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.37" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
-    <PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
-    <PackageReference Include="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
-    <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.2.23101.9" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
+    <PackageReference Include="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
+    <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/D2L.Bmx/nuget.config
+++ b/src/D2L.Bmx/nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
The biggest the motivation for the change is to enable [invariant globalization mode][1].
The default Alpine image doesn't have an ICU library, so the previous bmx Alpine binaries can't run on a clean Alpine container. Enabling invariant globalization removes the ICU dependency, which makes bmx run well on Alpine, and reduces the binary size a bit, too.

[1]: https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md