### PR TITLE
refactor/clean up Okta authn code

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -11,7 +11,7 @@ internal interface IConsolePrompter {
 	bool PromptAllowProjectConfig();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
-	OktaMfaFactor SelectMfa( OktaMfaFactor[]? mfaOptions );
+	OktaMfaFactor SelectMfa( OktaMfaFactor[] mfaOptions );
 	string GetMfaResponse( string mfaInputPrompt );
 }
 
@@ -112,10 +112,10 @@ internal class ConsolePrompter : IConsolePrompter {
 		return roles[index - 1];
 	}
 
-	OktaMfaFactor IConsolePrompter.SelectMfa( OktaMfaFactor[]? mfaOptions ) {
+	OktaMfaFactor IConsolePrompter.SelectMfa( OktaMfaFactor[] mfaOptions ) {
 		Console.Error.WriteLine( "MFA Required" );
 
-		if( mfaOptions is not { Length: > 0 } ) {
+		if( mfaOptions.Length == 0 ) {
 			throw new BmxException( "No MFA method have been set up for the current user." );
 		}
 

--- a/src/D2L.Bmx/Okta/Models/AuthenticateChallengeMfaOptions.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateChallengeMfaOptions.cs
@@ -1,7 +1,0 @@
-namespace D2L.Bmx.Okta.Models;
-
-internal record AuthenticateChallengeMfaOptions(
-	string FactorId,
-	string StateToken,
-	string? PassCode = null
-);

--- a/src/D2L.Bmx/Okta/Models/AuthenticateRequest.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateRequest.cs
@@ -1,6 +1,6 @@
 namespace D2L.Bmx.Okta.Models;
 
-internal record AuthenticateOptions(
+internal record AuthenticateRequest(
 	string Username,
 	string Password
 );

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -2,26 +2,24 @@ using System.Text.Json.Serialization;
 
 namespace D2L.Bmx.Okta.Models;
 
-internal record AuthenticateResponseInital(
+internal abstract record AuthenticateResponse {
+	public record MfaRequired( string StateToken, OktaMfaFactor[] Factors ) : AuthenticateResponse;
+	public record Success( string SessionToken ) : AuthenticateResponse;
+}
+
+internal record AuthenticateResponseRaw(
 	DateTimeOffset ExpiresAt,
 	[property: JsonConverter( typeof( JsonStringEnumConverter ) )]
 	AuthenticationStatus Status,
 	string? StateToken,
 	string? SessionToken,
 	[property: JsonPropertyName( "_embedded" )]
-	AuthenticateResponseEmbeddedInitial? Embedded
+	AuthenticateResponseEmbedded? Embedded
 );
 
-internal record AuthenticateResponseSuccess(
-	DateTimeOffset ExpiresAt,
-	[property: JsonConverter( typeof( JsonStringEnumConverter ) )]
-	AuthenticationStatus Status,
-	string? SessionToken
+internal record AuthenticateResponseEmbedded(
+	OktaMfaFactor[]? Factors
 );
-
-internal struct AuthenticateResponseEmbeddedInitial {
-	public OktaMfaFactor[]? Factors { get; set; }
-}
 
 internal record OktaMfaFactor(
 	string Id,

--- a/src/D2L.Bmx/Okta/Models/CreateSessionRequest.cs
+++ b/src/D2L.Bmx/Okta/Models/CreateSessionRequest.cs
@@ -1,5 +1,5 @@
 namespace D2L.Bmx.Okta.Models;
 
-internal record SessionOptions(
+internal record CreateSessionRequest(
 	string SessionToken
 );

--- a/src/D2L.Bmx/Okta/Models/IssueMfaChallengeRequest.cs
+++ b/src/D2L.Bmx/Okta/Models/IssueMfaChallengeRequest.cs
@@ -1,0 +1,5 @@
+namespace D2L.Bmx.Okta.Models;
+
+internal record IssueMfaChallengeRequest(
+	string StateToken
+);

--- a/src/D2L.Bmx/Okta/Models/Readme.md
+++ b/src/D2L.Bmx/Okta/Models/Readme.md
@@ -1,6 +1,4 @@
 Models for Okta authenticate, session and other APIs used by BMX
 
-Models here based off of models from the [okta-auth-dotnet](https://github.com/okta/okta-auth-dotnet) SDK.
-
 Please **note these models are incomplete, properties that BMX doesn't care about at present are left out**, Consult the Okta [API Docs](https://developer.okta.com/docs/reference/api/) to get the full picture
 of whats available via the API.

--- a/src/D2L.Bmx/Okta/Models/VerifyMfaChallengeResponseRequest.cs
+++ b/src/D2L.Bmx/Okta/Models/VerifyMfaChallengeResponseRequest.cs
@@ -1,0 +1,6 @@
+namespace D2L.Bmx.Okta.Models;
+
+internal record VerifyMfaChallengeResponseRequest(
+	string StateToken,
+	string PassCode
+);

--- a/src/D2L.Bmx/Okta/State/OktaAuthenticateState.cs
+++ b/src/D2L.Bmx/Okta/State/OktaAuthenticateState.cs
@@ -1,8 +1,0 @@
-using D2L.Bmx.Okta.Models;
-namespace D2L.Bmx.Okta.State;
-
-internal record OktaAuthenticateState(
-	string? OktaStateToken,
-	string? OktaSessionToken,
-	OktaMfaFactor[]? OktaMfaFactors
-);

--- a/src/D2L.Bmx/Okta/State/OktaAuthenticatedState.cs
+++ b/src/D2L.Bmx/Okta/State/OktaAuthenticatedState.cs
@@ -1,6 +1,0 @@
-namespace D2L.Bmx.Okta.State;
-
-internal record OktaAuthenticatedState(
-	bool SuccessfulAuthentication,
-	string OktaSessionId
-);

--- a/src/D2L.Bmx/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/SourceGenerationContext.cs
@@ -1,13 +1,14 @@
 using System.Text.Json.Serialization;
 using D2L.Bmx.Okta.Models;
+
 namespace D2L.Bmx.Okta;
 
 [JsonSourceGenerationOptions( PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase )]
-[JsonSerializable( typeof( AuthenticateOptions ) )]
-[JsonSerializable( typeof( AuthenticateChallengeMfaOptions ) )]
-[JsonSerializable( typeof( SessionOptions ) )]
-[JsonSerializable( typeof( AuthenticateResponseInital ) )]
-[JsonSerializable( typeof( AuthenticateResponseSuccess ) )]
+[JsonSerializable( typeof( AuthenticateRequest ) )]
+[JsonSerializable( typeof( IssueMfaChallengeRequest ) )]
+[JsonSerializable( typeof( VerifyMfaChallengeResponseRequest ) )]
+[JsonSerializable( typeof( CreateSessionRequest ) )]
+[JsonSerializable( typeof( AuthenticateResponseRaw ) )]
 [JsonSerializable( typeof( OktaSession ) )]
 [JsonSerializable( typeof( OktaApp[] ) )]
 [JsonSerializable( typeof( OktaMeResponse ) )]


### PR DESCRIPTION
* Remove bloat
  We have both `OktaAuthenticateState` and `OktaAuthenticatedState`... wut

* Simplify method signature and use better method/type names around Okta authentication API
  There're many `FooOptions` types that can be confusing when there's also the [options pattern][1] in .NET. Calling these types `FooRequest` is more in line with our convention.

* Better handle polymorphic responses from authentication API calls to give more accurate type (including nullability) info and helps clarify caller logic

[1]: https://learn.microsoft.com/en-us/dotnet/core/extensions/options