### PR TITLE
Don't create session file on read

### DIFF
--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetName>bmx</TargetName>
+    <AssemblyName>bmx</AssemblyName>
     <PublishAot>true</PublishAot>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -132,7 +132,7 @@ internal class OktaAuthenticator {
 	}
 
 	private List<OktaSessionCache> ReadOktaSessionCacheFile() {
-		var sourceCache = _sessionStorage.Sessions();
+		var sourceCache = _sessionStorage.GetSessions();
 		var currTime = DateTimeOffset.Now;
 		return sourceCache.Where( session => session.ExpiresAt > currTime ).ToList();
 	}


### PR DESCRIPTION
### Why

Currently the .NET bmx will create the ~/.bmx directory and an empty session file when the user doesn't have anything configured, which is a weird behaviour.
Creating directory and file should be in the `SaveSessions` method. BMX should leave no trace if the user doesn't configure anything.