### PR TITLE
selectively preserve AWSSDK types from trimming

### DIFF
--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RootNamespace>D2L.Bmx</RootNamespace>
-    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +18,13 @@
     <PackageReference Include="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- https://github.com/dotnet/linker/blob/main/docs/data-formats.md#descriptor-format -->
+    <EmbeddedResource Include="ILLink.Descriptors.xml">
+      <LogicalName>ILLink.Descriptors.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/D2L.Bmx/ILLink.Descriptors.xml
+++ b/src/D2L.Bmx/ILLink.Descriptors.xml
@@ -1,0 +1,16 @@
+<!--
+  Specify assemblies/types/members in this file to keep them from being trimmed.
+  This enalbes us to use native AOT with non-trim-friendly libraries.
+  It's more surgical than using the "partial" trim mode, and results in smaller executables.
+  See:
+    https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options#root-descriptors
+    https://github.com/dotnet/linker/blob/main/docs/data-formats.md#descriptor-format
+-->
+<linker>
+  <assembly fullname="AWSSDK.Core">
+    <!-- https://github.com/aws/aws-sdk-net/issues/2531 -->
+    <type fullname="Amazon.Util.Internal.PlatformServices.ApplicationInfo" />
+    <type fullname="Amazon.Util.Internal.PlatformServices.EnvironmentInfo" />
+    <type fullname="Amazon.Util.Internal.PlatformServices.NetworkReachability" />
+  </assembly>
+</linker>


### PR DESCRIPTION
To safely enable full trim mode and produce smaller executables.

For Windows executables, it brings the size down from 15.95 MiB to 12.62 MiB (~20% reduction).