### PR TITLE
remove allow_project_configs config option

### DIFF
--- a/src/D2L.Bmx/BmxConfig.cs
+++ b/src/D2L.Bmx/BmxConfig.cs
@@ -6,6 +6,5 @@ internal record BmxConfig(
 	string? Account,
 	string? Role,
 	string? Profile,
-	int? DefaultDuration,
-	bool AllowProjectConfigs
+	int? DefaultDuration
 );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -19,15 +19,10 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 		// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
 		var configBuilder = new ConfigurationBuilder().AddIniFile( configFileName, optional: true );
 
-		bool.TryParse( configBuilder.Build()["allow_project_configs"], out bool shouldReadProjectConfig );
-
 		FileInfo? projectConfigInfo = null;
+		projectConfigInfo = GetProjectConfigFileInfo();
 
-		if( shouldReadProjectConfig ) {
-			projectConfigInfo = GetProjectConfigFileInfo();
-		}
-
-		if( shouldReadProjectConfig && projectConfigInfo is not null ) {
+		if( projectConfigInfo is not null ) {
 			// Default file provider ignores files prefixed with ".", we need to provide our own as a result
 			var fileProvider =
 				new PhysicalFileProvider( projectConfigInfo.DirectoryName!, ExclusionFilters.None );
@@ -51,8 +46,7 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 			Account: config["account"],
 			Role: config["role"],
 			Profile: config["profile"],
-			DefaultDuration: defaultDuration,
-			AllowProjectConfigs: shouldReadProjectConfig
+			DefaultDuration: defaultDuration
 		);
 	}
 
@@ -77,9 +71,6 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 		}
 		if( config.DefaultDuration.HasValue ) {
 			writer.WriteLine( $"default_duration={config.DefaultDuration}" );
-		}
-		if( config.AllowProjectConfigs ) {
-			writer.WriteLine( $"allow_project_configs={config.AllowProjectConfigs}" );
 		}
 	}
 

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -19,8 +19,7 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 		// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
 		var configBuilder = new ConfigurationBuilder().AddIniFile( configFileName, optional: true );
 
-		FileInfo? projectConfigInfo = null;
-		projectConfigInfo = GetProjectConfigFileInfo();
+		FileInfo? projectConfigInfo = GetProjectConfigFileInfo();
 
 		if( projectConfigInfo is not null ) {
 			// Default file provider ignores files prefixed with ".", we need to provide our own as a result

--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -28,16 +28,14 @@ internal class ConfigureHandler {
 			defaultDuration = _consolePrompter.PromptDefaultDuration();
 		}
 
-		bool allowProjectConfigs = _consolePrompter.PromptAllowProjectConfig();
-
 		BmxConfig config = new(
 			Org: org,
 			User: user,
 			Account: null,
 			Role: null,
 			Profile: null,
-			DefaultDuration: defaultDuration,
-			AllowProjectConfigs: allowProjectConfigs );
+			DefaultDuration: defaultDuration
+		);
 		_configProvider.SaveConfiguration( config );
 		Console.WriteLine( "Your configuration has been created. Okta sessions will now also be cached." );
 	}

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -10,7 +10,6 @@ internal interface IConsolePrompter {
 	string PromptUser();
 	string PromptPassword();
 	int? PromptDefaultDuration();
-	bool PromptAllowProjectConfig();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
 	OktaMfaFactor SelectMfa( OktaMfaFactor[] mfaOptions );
@@ -101,15 +100,6 @@ internal class ConsolePrompter : IConsolePrompter {
 			return null;
 		}
 		return defaultDuration;
-	}
-
-	bool IConsolePrompter.PromptAllowProjectConfig() {
-		Console.Error.Write( "Allow project level .bmx config file? (true/false, default: false): " );
-		string? input = _stdinReader.ReadLine();
-		if( input is null || !bool.TryParse( input, out bool allowProjectConfigs ) ) {
-			return false;
-		}
-		return allowProjectConfigs;
 	}
 
 	string IConsolePrompter.PromptAccount( string[] accounts ) {


### PR DESCRIPTION
### Why

Slack discussion [here](https://d2l.slack.com/archives/G4P099831/p1685471844688699)

tldr: This feature came in the Go version without previously being in V1 and guessing we left it as an experimental flag. Partly because it could crash on Linux systems working its way up the directories. This isn't a problem now in .NET version. 

This feature has matured enough to become a default setting. So now we will simply always look for a .bmx file in the CWD. 