### PR TITLE
limit max search depth for project config file

### DIFF
--- a/src/D2L.Bmx/BmxPaths.cs
+++ b/src/D2L.Bmx/BmxPaths.cs
@@ -1,7 +1,6 @@
-
 namespace D2L.Bmx;
-internal class BmxPaths {
 
+internal static class BmxPaths {
 	public static readonly string USER_HOME_DIR = Environment.GetFolderPath( Environment.SpecialFolder.UserProfile );
 	public static readonly string BMX_DIR = Path.Join( USER_HOME_DIR, ".bmx" );
 	public static readonly string SESSIONS_FILE_NAME = Path.Join( BMX_DIR, "sessions" );


### PR DESCRIPTION
### Why

To ensure that project config file lookup won't crash the app or get it stuck.

Related discussion: https://d2l.slack.com/archives/G4P099831/p1685471844688699

[Hide whitespace changes](https://github.com/Brightspace/bmx/pull/326/files?w=1)