### PR TITLE
write: use ini parser to format credentials file

### DIFF
--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.37" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -6,6 +6,7 @@ using Amazon.SecurityToken;
 using D2L.Bmx;
 using D2L.Bmx.Aws;
 using D2L.Bmx.Okta;
+using IniParser;
 
 var rootCommand = new RootCommand( "BMX grants you API access to your AWS accounts!" );
 
@@ -131,6 +132,7 @@ var writeCommand = new Command( "write", "Write to AWS credentials file" ) {
 writeCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var consolePrompter = new ConsolePrompter();
 	var config = new BmxConfigProvider().GetConfiguration();
+	var parser = new FileIniDataParser();
 	var handler = new WriteHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
@@ -142,7 +144,8 @@ writeCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAs
 			consolePrompter,
 			config ),
 		consolePrompter,
-		config
+		config,
+		parser
 	);
 	return handler.HandleAsync(
 		org: context.ParseResult.GetValueForOption( orgOption ),

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -132,7 +132,6 @@ var writeCommand = new Command( "write", "Write to AWS credentials file" ) {
 writeCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var consolePrompter = new ConsolePrompter();
 	var config = new BmxConfigProvider().GetConfiguration();
-	var parser = new FileIniDataParser();
 	var handler = new WriteHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
@@ -145,7 +144,7 @@ writeCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAs
 			config ),
 		consolePrompter,
 		config,
-		parser
+		new FileIniDataParser()
 	);
 	return handler.HandleAsync(
 		org: context.ParseResult.GetValueForOption( orgOption ),

--- a/src/D2L.Bmx/Properties/launchSettings.json
+++ b/src/D2L.Bmx/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "D2L.Bmx": {
+      "commandName": "Project",
+      "commandLineArgs": "write"
+    }
+  }
+}

--- a/src/D2L.Bmx/Properties/launchSettings.json
+++ b/src/D2L.Bmx/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "D2L.Bmx": {
-      "commandName": "Project",
-      "commandLineArgs": "write"
-    }
-  }
-}

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -1,6 +1,5 @@
 using Amazon.Runtime.CredentialManagement;
 using IniParser;
-using IniParser.Model.Configuration;
 
 namespace D2L.Bmx;
 
@@ -15,13 +14,14 @@ internal class WriteHandler {
 		OktaAuthenticator oktaAuth,
 		AwsCredsCreator awsCreds,
 		IConsolePrompter consolePrompter,
-		BmxConfig config
+		BmxConfig config,
+		FileIniDataParser parser
 	) {
 		_oktaAuth = oktaAuth;
 		_awsCreds = awsCreds;
 		_consolePrompter = consolePrompter;
 		_config = config;
-		_parser = new FileIniDataParser();
+		_parser = parser;
 	}
 
 	public async Task HandleAsync(

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -61,7 +61,6 @@ internal class WriteHandler {
 		data[profile]["aws_access_key_id"] = awsCreds.AccessKeyId;
 		data[profile]["aws_secret_access_key"] = awsCreds.SecretAccessKey;
 		data[profile]["aws_session_token"] = awsCreds.SessionToken;
-		data[profile]["abxc"] = awsCreds.SessionToken;
 
 		_parser.WriteFile( credentialsFile.FilePath, data );
 	}

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -21,10 +21,6 @@ internal class WriteHandler {
 		_awsCreds = awsCreds;
 		_consolePrompter = consolePrompter;
 		_config = config;
-
-		var x = new IniParserConfiguration();
-
-
 		_parser = new FileIniDataParser();
 	}
 

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -1,6 +1,5 @@
 using Amazon.Runtime.CredentialManagement;
 using IniParser;
-using IniParser.Model;
 using IniParser.Model.Configuration;
 
 namespace D2L.Bmx;


### PR DESCRIPTION
### Why

The `SharedCredentialsFile` has a good implementation for working with ini files but the output is that of `x=y`. The GO version of BMX had the output such that every `=` sign for each line was aligned. 

### How

Use a third party ini parser library that will let us update / create profiles. The libraries I looked through don't have this same feature for dotnet. 

I considered writing something custom to give us the same kind of output here. While I got that working, I was worried of edge cases where the time spent wouldn't be worth it. Last thing I want is to break someone's credentials file.

So the new output will be in the format `x = y` instead of `x=y`