### PR TITLE
use POSIX compliant stty arguments

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -200,7 +200,7 @@ internal class ConsolePrompter : IConsolePrompter {
 
 	private static string GetCurrentTerminalSettings() {
 		var startInfo = new ProcessStartInfo( "stty" );
-		startInfo.ArgumentList.Add( "--save" );
+		startInfo.ArgumentList.Add( "-g" );
 		startInfo.RedirectStandardOutput = true;
 		using var p = Process.Start( startInfo ) ?? throw new BmxException( "Terminal error" );
 		p.WaitForExit();


### PR DESCRIPTION
`--save` isn't in the POSIX spec, and Mac doesn't implement it, so output is messed up after password input.
Switch to `-g` which is equivalent and defined in POSIX.

See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/stty.html

Related discussion: https://d2l.slack.com/archives/G4P099831/p1687794940963309