### PR TITLE
configure: prevent data stomping

### DIFF
--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -8,10 +8,10 @@ namespace D2L.Bmx;
 
 internal interface IBmxConfigProvider {
 	BmxConfig GetConfiguration();
-	void SaveConfiguration( BmxConfig config, FileIniDataParser parser );
+	void SaveConfiguration( BmxConfig config );
 }
 
-internal class BmxConfigProvider : IBmxConfigProvider {
+internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvider {
 	public BmxConfig GetConfiguration() {
 		// Main config is at ~/.bmx/config
 		string configFileName = BmxPaths.CONFIG_FILE_NAME;
@@ -49,7 +49,7 @@ internal class BmxConfigProvider : IBmxConfigProvider {
 		);
 	}
 
-	public void SaveConfiguration( BmxConfig config, FileIniDataParser parser ) {
+	public void SaveConfiguration( BmxConfig config ) {
 		if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
 			Directory.CreateDirectory( BmxPaths.BMX_DIR );
 		}

--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -1,11 +1,9 @@
-using IniParser;
 
 namespace D2L.Bmx;
 
 internal class ConfigureHandler(
 	IBmxConfigProvider configProvider,
-	IConsolePrompter consolePrompter,
-	FileIniDataParser parser
+	IConsolePrompter consolePrompter
 ) {
 	public void Handle(
 		string? org,
@@ -34,7 +32,7 @@ internal class ConfigureHandler(
 			Profile: null,
 			Duration: duration
 		);
-		configProvider.SaveConfiguration( config, parser );
+		configProvider.SaveConfiguration( config );
 		Console.WriteLine( "Your configuration has been created. Okta sessions will now also be cached." );
 	}
 }

--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -1,6 +1,12 @@
+using IniParser;
+
 namespace D2L.Bmx;
 
-internal class ConfigureHandler( IBmxConfigProvider configProvider, IConsolePrompter consolePrompter ) {
+internal class ConfigureHandler(
+	IBmxConfigProvider configProvider,
+	IConsolePrompter consolePrompter,
+	FileIniDataParser parser
+) {
 	public void Handle(
 		string? org,
 		string? user,
@@ -9,11 +15,11 @@ internal class ConfigureHandler( IBmxConfigProvider configProvider, IConsoleProm
 	) {
 
 		if( string.IsNullOrEmpty( org ) && !nonInteractive ) {
-			org = consolePrompter.PromptOrg();
+			org = consolePrompter.PromptOrg( allowEmptyInput: true );
 		}
 
 		if( string.IsNullOrEmpty( user ) && !nonInteractive ) {
-			user = consolePrompter.PromptUser();
+			user = consolePrompter.PromptUser( allowEmptyInput: true );
 		}
 
 		if( duration is null && !nonInteractive ) {
@@ -28,7 +34,7 @@ internal class ConfigureHandler( IBmxConfigProvider configProvider, IConsoleProm
 			Profile: null,
 			Duration: duration
 		);
-		configProvider.SaveConfiguration( config );
+		configProvider.SaveConfiguration( config, parser );
 		Console.WriteLine( "Your configuration has been created. Okta sessions will now also be cached." );
 	}
 }

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -5,9 +5,9 @@ using D2L.Bmx.Okta.Models;
 namespace D2L.Bmx;
 
 internal interface IConsolePrompter {
-	string PromptOrg();
+	string PromptOrg( bool allowEmptyInput );
 	string PromptProfile();
-	string PromptUser();
+	string PromptUser( bool allowEmptyInput );
 	string PromptPassword();
 	int? PromptDuration();
 	string PromptAccount( string[] accounts );
@@ -33,10 +33,11 @@ internal class ConsolePrompter : IConsolePrompter {
 			FileAccess.Read
 		) );
 
-	string IConsolePrompter.PromptOrg() {
-		Console.Error.Write( "The tenant name or full domain name of the Okta organization: " );
+	string IConsolePrompter.PromptOrg( bool allowEmptyInput ) {
+		Console.Error.Write(
+			$"The tenant name or full domain name of the Okta organization {( allowEmptyInput ? "(Optional): " : ": " )}" );
 		string? org = _stdinReader.ReadLine();
-		if( string.IsNullOrEmpty( org ) ) {
+		if( org is null || ( org.Equals( "" ) && !allowEmptyInput ) ) {
 			throw new BmxException( "Invalid org input" );
 		}
 
@@ -53,10 +54,10 @@ internal class ConsolePrompter : IConsolePrompter {
 		return profile;
 	}
 
-	string IConsolePrompter.PromptUser() {
-		Console.Error.Write( "Okta Username: " );
+	string IConsolePrompter.PromptUser( bool allowEmptyInput ) {
+		Console.Error.Write( $"Okta Username {( allowEmptyInput ? " (Optional): " : ": " )}" );
 		string? user = _stdinReader.ReadLine();
-		if( string.IsNullOrEmpty( user ) ) {
+		if( user is null || ( user.Equals( "" ) && !allowEmptyInput ) ) {
 			throw new BmxException( "Invalid user input" );
 		}
 

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -37,7 +37,7 @@ internal class ConsolePrompter : IConsolePrompter {
 		Console.Error.Write(
 			$"The tenant name or full domain name of the Okta organization {( allowEmptyInput ? "(Optional): " : ": " )}" );
 		string? org = _stdinReader.ReadLine();
-		if( org is null || ( org.Equals( "" ) && !allowEmptyInput ) ) {
+		if( org is null || ( string.IsNullOrWhiteSpace( org ) && !allowEmptyInput ) ) {
 			throw new BmxException( "Invalid org input" );
 		}
 
@@ -57,7 +57,7 @@ internal class ConsolePrompter : IConsolePrompter {
 	string IConsolePrompter.PromptUser( bool allowEmptyInput ) {
 		Console.Error.Write( $"Okta Username {( allowEmptyInput ? " (Optional): " : ": " )}" );
 		string? user = _stdinReader.ReadLine();
-		if( user is null || ( user.Equals( "" ) && !allowEmptyInput ) ) {
+		if( user is null || ( string.IsNullOrWhiteSpace( user ) && !allowEmptyInput ) ) {
 			throw new BmxException( "Invalid user input" );
 		}
 

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -19,7 +19,7 @@ internal class OktaAuthenticator(
 			if( !string.IsNullOrEmpty( config.Org ) ) {
 				org = config.Org;
 			} else if( !nonInteractive ) {
-				org = consolePrompter.PromptOrg();
+				org = consolePrompter.PromptOrg( allowEmptyInput: false );
 			} else {
 				throw new BmxException( "Org value was not provided" );
 			}
@@ -29,7 +29,7 @@ internal class OktaAuthenticator(
 			if( !string.IsNullOrEmpty( config.User ) ) {
 				user = config.User;
 			} else if( !nonInteractive ) {
-				user = consolePrompter.PromptUser();
+				user = consolePrompter.PromptUser( allowEmptyInput: false );
 			} else {
 				throw new BmxException( "User value was not provided" );
 			}

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -40,7 +40,8 @@ var configureCommand = new Command( "configure", "Create a bmx config file to sa
 configureCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var handler = new ConfigureHandler(
 		new BmxConfigProvider(),
-		new ConsolePrompter() );
+		new ConsolePrompter(),
+		new FileIniDataParser() );
 	handler.Handle(
 		org: context.ParseResult.GetValueForOption( orgOption ),
 		user: context.ParseResult.GetValueForOption( userOption ),
@@ -199,6 +200,7 @@ static async Task RunWithErrorHandlingAsync( InvocationContext context, Func<Tas
 			Console.Error.WriteLine( e.Message );
 		} else {
 			Console.Error.WriteLine( "BMX exited with unexpected internal error" );
+			Console.Error.WriteLine( e.ToString() );
 		}
 		if( Environment.GetEnvironmentVariable( "BMX_DEBUG" ) == "1" ) {
 			Console.Error.WriteLine( e );

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -39,9 +39,8 @@ var configureCommand = new Command( "configure", "Create a bmx config file to sa
 
 configureCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var handler = new ConfigureHandler(
-		new BmxConfigProvider(),
-		new ConsolePrompter(),
-		new FileIniDataParser() );
+		new BmxConfigProvider( new FileIniDataParser() ),
+		new ConsolePrompter() );
 	handler.Handle(
 		org: context.ParseResult.GetValueForOption( orgOption ),
 		user: context.ParseResult.GetValueForOption( userOption ),
@@ -88,7 +87,7 @@ var printCommand = new Command( "print", "Returns the AWS credentials in text as
 
 printCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var consolePrompter = new ConsolePrompter();
-	var config = new BmxConfigProvider().GetConfiguration();
+	var config = new BmxConfigProvider( new FileIniDataParser() ).GetConfiguration();
 	var handler = new PrintHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
@@ -134,7 +133,7 @@ var writeCommand = new Command( "write", "Write to AWS credentials file" ) {
 
 writeCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var consolePrompter = new ConsolePrompter();
-	var config = new BmxConfigProvider().GetConfiguration();
+	var config = new BmxConfigProvider( new FileIniDataParser() ).GetConfiguration();
 	var handler = new WriteHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
@@ -170,7 +169,7 @@ var loginCommand = new Command( "login", "Login to Okta and create a session" ) 
 
 loginCommand.SetHandler( ( InvocationContext context ) => RunWithErrorHandlingAsync( context, () => {
 	var consolePrompter = new ConsolePrompter();
-	var config = new BmxConfigProvider().GetConfiguration();
+	var config = new BmxConfigProvider( new FileIniDataParser() ).GetConfiguration();
 	var handler = new LoginHandler(
 		new OktaAuthenticator(
 			new OktaApi(),

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -200,7 +200,6 @@ static async Task RunWithErrorHandlingAsync( InvocationContext context, Func<Tas
 			Console.Error.WriteLine( e.Message );
 		} else {
 			Console.Error.WriteLine( "BMX exited with unexpected internal error" );
-			Console.Error.WriteLine( e.ToString() );
 		}
 		if( Environment.GetEnvironmentVariable( "BMX_DEBUG" ) == "1" ) {
 			Console.Error.WriteLine( e );


### PR DESCRIPTION
### Why

Currently configure command will overwrite all existing settings in the config file

### How

We can use an ini parser the same way we do for `bmx write` and not do a complete rewrite of the file. This requires us to change some of the console prompter code as it currently will throw an exception if no input is given

Related trello card [here](https://trello.com/c/VFHzMaY4/1295-configure-command-should-keep-existing-entries-in-the-config-file)