### PR TITLE
write: fix ini parser encoding to UTF-8

### DIFF
--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Amazon.Runtime.CredentialManagement;
 using IniParser;
 
@@ -44,6 +45,6 @@ internal class WriteHandler(
 		data[profile]["aws_secret_access_key"] = awsCreds.SecretAccessKey;
 		data[profile]["aws_session_token"] = awsCreds.SessionToken;
 
-		parser.WriteFile( credentialsFile.FilePath, data );
+		parser.WriteFile( credentialsFile.FilePath, data, new UTF8Encoding( false ) );
 	}
 }


### PR DESCRIPTION
### Why

Parser defaults to UTF-8-BOM and credentials file needs to be UTF-8. Current version of write will cause aws cli to give error about how it can't parse the credentials file