### PR TITLE
Use ini-parser-netstandard for all ini file parsing

### DIFF
--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -25,7 +25,7 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 		FileInfo? projectConfigInfo = GetProjectConfigFileInfo();
 
 		if( projectConfigInfo is not null ) {
-			var configFilePath = Path.Combine( projectConfigInfo.DirectoryName ?? "", projectConfigInfo.Name );
+			string configFilePath = Path.Combine( projectConfigInfo.DirectoryName ?? "", projectConfigInfo.Name );
 			try {
 				var tempdata = parser.ReadFile( configFilePath );
 				data.Merge( tempdata );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -12,7 +12,7 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 	public BmxConfig GetConfiguration() {
 		// Main config is at ~/.bmx/config
 		string configFileName = BmxPaths.CONFIG_FILE_NAME;
-		IniData data = new IniData();
+		var data = new IniData();
 		if( File.Exists( configFileName ) ) {
 			var tempdata = parser.ReadFile( configFileName );
 			data.Merge( tempdata );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -1,8 +1,3 @@
-using System.Runtime.InteropServices;
-using IniParser;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.FileProviders.Physical;
-
 namespace D2L.Bmx;
 
 internal interface IBmxConfigProvider {

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -14,20 +14,24 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 		string configFileName = BmxPaths.CONFIG_FILE_NAME;
 		var data = new IniData();
 		if( File.Exists( configFileName ) ) {
-			var tempdata = parser.ReadFile( configFileName );
-			data.Merge( tempdata );
+			try {
+				var tempdata = parser.ReadFile( configFileName );
+				data.Merge( tempdata );
+			} catch( IniParser.Exceptions.ParsingException ) {
+				//No read permission?
+			}
 		}
 		// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
 		FileInfo? projectConfigInfo = GetProjectConfigFileInfo();
 
 		if( projectConfigInfo is not null ) {
-			// Default file provider ignores files prefixed with ".", we need to provide our own as a result
-			//var fileProvider =
-			//	new PhysicalFileProvider( projectConfigInfo.DirectoryName!, ExclusionFilters.None );
-			var tempdata = parser.ReadFile( projectConfigInfo.Name );
-			data.Merge( tempdata );
-			//configBuilder.AddIniFile( fileProvider, projectConfigInfo.Name, optional: false,
-			//	reloadOnChange: false );
+			var configFilePath = Path.Combine( projectConfigInfo.DirectoryName ?? "", projectConfigInfo.Name );
+			try {
+				var tempdata = parser.ReadFile( configFilePath );
+				data.Merge( tempdata );
+			} catch( IniParser.Exceptions.ParsingException ) {
+				//No read permission?
+			}
 		}
 
 		int? duration = null;

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using IniParser;
 using IniParser.Model;
-using System;
 namespace D2L.Bmx;
 
 internal interface IBmxConfigProvider {

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -18,19 +18,18 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 				var tempdata = parser.ReadFile( configFileName );
 				data.Merge( tempdata );
 			} catch( Exception ) {
-				Console.Write( "Error occur while parsing config file." );
+				Console.Error.Write( $"WARNING: Failed to load the global config file {configFileName}." );
 			}
 		}
 		// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
 		FileInfo? projectConfigInfo = GetProjectConfigFileInfo();
 
 		if( projectConfigInfo is not null ) {
-			string configFilePath = Path.Combine( projectConfigInfo.DirectoryName ?? "", projectConfigInfo.Name );
 			try {
-				var tempdata = parser.ReadFile( configFilePath );
+				var tempdata = parser.ReadFile( projectConfigInfo.FullName );
 				data.Merge( tempdata );
 			} catch( Exception ) {
-				Console.Write( "Error occur while parsing additional config file." );
+				Console.Error.Write( $"WARNING: Failed to load the local config file {projectConfigInfo.FullName}." );
 			}
 		}
 

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using IniParser;
 using IniParser.Model;
+using System;
 namespace D2L.Bmx;
 
 internal interface IBmxConfigProvider {
@@ -17,8 +18,8 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 			try {
 				var tempdata = parser.ReadFile( configFileName );
 				data.Merge( tempdata );
-			} catch( IniParser.Exceptions.ParsingException ) {
-				//No read permission?
+			} catch( Exception ) {
+				Console.Write( "Error occur while parsing config file." );
 			}
 		}
 		// If set, we recursively look up from CWD (all the way to root) for additional bmx config files (labelled as .bmx)
@@ -29,8 +30,8 @@ internal class BmxConfigProvider( FileIniDataParser parser ) : IBmxConfigProvide
 			try {
 				var tempdata = parser.ReadFile( configFilePath );
 				data.Merge( tempdata );
-			} catch( IniParser.Exceptions.ParsingException ) {
-				//No read permission?
+			} catch( Exception ) {
+				Console.Write( "Error occur while parsing additional config file." );
 			}
 		}
 

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+using IniParser;
 namespace D2L.Bmx;
 
 internal interface IBmxConfigProvider {

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.37" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0-preview.5.23280.8" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0-preview.5.23280.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Why
IniParser and Microsoft.Extensions.Configuration.Ini have roughly the same functionalities. Using Iniparser only to make code more consistent