### PR TITLE
check for updates on run

### DIFF
--- a/src/D2L.Bmx/BmxPaths.cs
+++ b/src/D2L.Bmx/BmxPaths.cs
@@ -5,5 +5,5 @@ internal static class BmxPaths {
 	public static readonly string BMX_DIR = Path.Join( USER_HOME_DIR, ".bmx" );
 	public static readonly string SESSIONS_FILE_NAME = Path.Join( BMX_DIR, "sessions" );
 	public static readonly string CONFIG_FILE_NAME = Path.Join( BMX_DIR, "config" );
-	public static readonly string UPDATE_CHECK_FILE_NAME = Path.Join( BMX_DIR, "latest_version" );
+	public static readonly string UPDATE_CHECK_FILE_NAME = Path.Join( BMX_DIR, "update_check" );
 }

--- a/src/D2L.Bmx/BmxPaths.cs
+++ b/src/D2L.Bmx/BmxPaths.cs
@@ -5,4 +5,5 @@ internal static class BmxPaths {
 	public static readonly string BMX_DIR = Path.Join( USER_HOME_DIR, ".bmx" );
 	public static readonly string SESSIONS_FILE_NAME = Path.Join( BMX_DIR, "sessions" );
 	public static readonly string CONFIG_FILE_NAME = Path.Join( BMX_DIR, "config" );
+	public static readonly string UPDATE_CHECK_FILE_NAME = Path.Join( BMX_DIR, "latest_version" );
 }

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -7,7 +7,6 @@ using Amazon.SecurityToken;
 using D2L.Bmx;
 using D2L.Bmx.Aws;
 using D2L.Bmx.Okta;
-using D2L.Bmx.Okta.Models;
 using IniParser;
 
 

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -201,10 +201,15 @@ var rootCommand = new RootCommand( "BMX grants you API access to your AWS accoun
 // start bmx
 return await new CommandLineBuilder( rootCommand )
 	.UseDefaults()
-	.AddMiddleware( async ( context, next ) => {
+	.AddMiddleware( async (
+		context,
+		next
+	) => {
 		await UpdateChecker.CheckForUpdatesAsync( configProvider.GetConfiguration() );
 		await next( context );
-	} )
+	},
+		System.CommandLine.Invocation.MiddlewareOrder.ExceptionHandler + 1
+	)
 	.UseExceptionHandler( ( exception, context ) => {
 		Console.ResetColor();
 		Console.ForegroundColor = ConsoleColor.Red;

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -213,7 +213,6 @@ return await new CommandLineBuilder( rootCommand )
 			Console.Error.WriteLine( exception.Message );
 		} else {
 			Console.Error.WriteLine( "BMX exited with unexpected internal error" );
-			Console.Error.WriteLine( exception.ToString() );
 		}
 		if( Environment.GetEnvironmentVariable( "BMX_DEBUG" ) == "1" ) {
 			Console.Error.WriteLine( exception );

--- a/src/D2L.Bmx/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/SourceGenerationContext.cs
@@ -13,5 +13,6 @@ namespace D2L.Bmx;
 [JsonSerializable( typeof( OktaApp[] ) )]
 [JsonSerializable( typeof( OktaMeResponse ) )]
 [JsonSerializable( typeof( List<OktaSessionCache> ) )]
+[JsonSerializable( typeof( GithubRelease ) )]
 internal partial class SourceGenerationContext : JsonSerializerContext {
 }

--- a/src/D2L.Bmx/SourceGenerationContext.cs
+++ b/src/D2L.Bmx/SourceGenerationContext.cs
@@ -14,5 +14,6 @@ namespace D2L.Bmx;
 [JsonSerializable( typeof( OktaMeResponse ) )]
 [JsonSerializable( typeof( List<OktaSessionCache> ) )]
 [JsonSerializable( typeof( GithubRelease ) )]
+[JsonSerializable( typeof( UpdateCheckCache ) )]
 internal partial class SourceGenerationContext : JsonSerializerContext {
 }

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace D2L.Bmx;
-internal class UpdateChecker {
+internal static class UpdateChecker {
 
 	public static async Task CheckForUpdatesAsync( BmxConfig config ) {
 		try {

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -3,14 +3,14 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace D2L.Bmx; 
+namespace D2L.Bmx;
 internal class UpdateChecker {
 
 	public static async Task CheckForUpdatesAsync( BmxConfig config ) {
 		try {
 			string? savedLatestVersion = GetSavedLatestVersion();
 			var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
-			var latestVersion = new Version( savedVersion ?? "0.0.0" );
+			var latestVersion = new Version( savedLatestVersion ?? "0.0.0" );
 			if( ShouldFetchLatestVersion( savedLatestVersion ) ) {
 				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 			}

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -58,7 +58,7 @@ internal class UpdateChecker {
 		var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
 		response.EnsureSuccessStatusCode();
 
-		using var responseStream = await response.Content.ReadAsStreamAsync();
+		await using var responseStream = await response.Content.ReadAsStreamAsync();
 		var releaseData = await JsonSerializer.DeserializeAsync(
 			responseStream,
 			SourceGenerationContext.Default.GithubRelease

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -32,7 +32,6 @@ namespace D2L.Bmx {
 				}
 			} catch( Exception ex ) {
 				// Give up and don't bother telling the user we couldn't check for updates
-				Console.Error.WriteLine( ex.ToString() );
 			}
 		}
 

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -15,7 +15,7 @@ internal class UpdateChecker {
 				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 			}
 
-			string updateLocation = ( string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase ) )
+			string updateLocation = string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase )
 				? "https://bmx.d2l.dev"
 				: "https://github.com/Brightspace/bmx/releases/latest";
 

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -1,121 +1,120 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Runtime.InteropServices;
 
-namespace D2L.Bmx {
-	internal class UpdateChecker {
+namespace D2L.Bmx; 
+internal class UpdateChecker {
 
-		public static async Task CheckForUpdatesAsync( BmxConfig config ) {
-			try {
-				var savedLatestVersion = GetSavedLatestVersion();
-				var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
-				var latestVersion = new Version( savedVersion ?? "0.0.0" );
-				if( ShouldFetchLatestVersion( savedLatestVersion ) ) {
-					latestVersion = new Version( await GetLatestReleaseVersionAsync() );
-				}
-
-				var updateLocation = ( string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase ) )
-					? "https://bmx.d2l.dev"
-					: "https://github.com/Brightspace/bmx/releases/latest";
-
-				if( latestVersion > localVersion ) {
-					DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
-						$"Upgrade now at {updateLocation}" );
-				}
-			} catch( Exception ex ) {
-				// Give up and don't bother telling the user we couldn't check for updates
+	public static async Task CheckForUpdatesAsync( BmxConfig config ) {
+		try {
+			string? savedLatestVersion = GetSavedLatestVersion();
+			var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
+			var latestVersion = new Version( savedVersion ?? "0.0.0" );
+			if( ShouldFetchLatestVersion( savedLatestVersion ) ) {
+				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 			}
+
+			string updateLocation = ( string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase ) )
+				? "https://bmx.d2l.dev"
+				: "https://github.com/Brightspace/bmx/releases/latest";
+
+			if( latestVersion > localVersion ) {
+				DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
+					$"Upgrade now at {updateLocation}" );
+			}
+		} catch( Exception ex ) {
+			// Give up and don't bother telling the user we couldn't check for updates
 		}
+	}
 
-		private static void DisplayUpdateMessage( string message ) {
-			var originalBackgroundColor = Console.BackgroundColor;
-			var originalForegroundColor = Console.ForegroundColor;
+	private static void DisplayUpdateMessage( string message ) {
+		var originalBackgroundColor = Console.BackgroundColor;
+		var originalForegroundColor = Console.ForegroundColor;
 
-			Console.BackgroundColor = ConsoleColor.Gray;
-			Console.ForegroundColor = ConsoleColor.Black;
+		Console.BackgroundColor = ConsoleColor.Gray;
+		Console.ForegroundColor = ConsoleColor.Black;
 
-			var lines = message.Split( "\n" );
-			int consoleWidth = Console.WindowWidth;
+		string[] lines = message.Split( "\n" );
+		int consoleWidth = Console.WindowWidth;
 
-			foreach( var line in lines ) {
-				Console.Error.Write( line.PadRight( consoleWidth ) );
-				Console.Error.WriteLine();
-			}
-
-			Console.BackgroundColor = originalBackgroundColor;
-			Console.ForegroundColor = originalForegroundColor;
-			Console.ResetColor();
+		foreach( string line in lines ) {
+			Console.Error.Write( line.PadRight( consoleWidth ) );
 			Console.Error.WriteLine();
 		}
 
-		private static async Task<string> GetLatestReleaseVersionAsync() {
-			using var httpClient = new HttpClient {
-				BaseAddress = new Uri( "https://api.github.com" ),
-				Timeout = TimeSpan.FromSeconds( 5 )
-			};
-			httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
-			var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
-			response.EnsureSuccessStatusCode();
-
-			using var responseStream = await response.Content.ReadAsStreamAsync();
-			var releaseData = await JsonSerializer.DeserializeAsync(
-				responseStream,
-				SourceGenerationContext.Default.GithubRelease
-			);
-			string content = await response.Content.ReadAsStringAsync();
-			string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
-			SaveLatestVersion( version );
-			return version;
-		}
-
-		private static void SaveLatestVersion( string version ) {
-			if( string.IsNullOrWhiteSpace( version ) ) {
-				return;
-			}
-			if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
-				Directory.CreateDirectory( BmxPaths.BMX_DIR );
-			}
-			var op = new FileStreamOptions {
-				Mode = FileMode.OpenOrCreate,
-				Access = FileAccess.ReadWrite,
-			};
-			if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
-				op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-			}
-			using FileStream fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );
-			using StreamWriter writer = new StreamWriter( fs );
-			writer.WriteLine( version );
-		}
-
-		private static DateTimeOffset? GetTimeLastChecked() {
-			if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
-				return null;
-			}
-			return File.GetLastWriteTimeUtc( BmxPaths.UPDATE_CHECK_FILE_NAME );
-		}
-
-		private static bool ShouldFetchLatestVersion( string? savedVersion ) {
-			if( string.IsNullOrWhiteSpace( savedVersion ) ) {
-				return true;
-			}
-			var savedTimestamp = GetTimeLastChecked();
-			if( !savedTimestamp.HasValue || ( DateTimeOffset.UtcNow - savedTimestamp.Value ) > TimeSpan.FromDays( 1 ) ) {
-				return true;
-			}
-			return false;
-		}
-
-		private static string? GetSavedLatestVersion() {
-			if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
-				return null;
-			}
-			return File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
-		}
+		Console.BackgroundColor = originalBackgroundColor;
+		Console.ForegroundColor = originalForegroundColor;
+		Console.ResetColor();
+		Console.Error.WriteLine();
 	}
 
-	internal record GithubRelease {
-		[JsonPropertyName( "tag_name" )]
-		public string? TagName { get; set; }
+	private static async Task<string> GetLatestReleaseVersionAsync() {
+		using var httpClient = new HttpClient {
+			BaseAddress = new Uri( "https://api.github.com" ),
+			Timeout = TimeSpan.FromSeconds( 5 )
+		};
+		httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
+		var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
+		response.EnsureSuccessStatusCode();
+
+		using var responseStream = await response.Content.ReadAsStreamAsync();
+		var releaseData = await JsonSerializer.DeserializeAsync(
+			responseStream,
+			SourceGenerationContext.Default.GithubRelease
+		);
+		string content = await response.Content.ReadAsStringAsync();
+		string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
+		SaveLatestVersion( version );
+		return version;
 	}
+
+	private static void SaveLatestVersion( string version ) {
+		if( string.IsNullOrWhiteSpace( version ) ) {
+			return;
+		}
+		if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
+			Directory.CreateDirectory( BmxPaths.BMX_DIR );
+		}
+		var op = new FileStreamOptions {
+			Mode = FileMode.OpenOrCreate,
+			Access = FileAccess.ReadWrite,
+		};
+		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+		}
+		using var fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );
+		using var writer = new StreamWriter( fs );
+		writer.WriteLine( version );
+	}
+
+	private static DateTimeOffset? GetTimeLastChecked() {
+		if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
+			return null;
+		}
+		return File.GetLastWriteTimeUtc( BmxPaths.UPDATE_CHECK_FILE_NAME );
+	}
+
+	private static bool ShouldFetchLatestVersion( string? savedVersion ) {
+		if( string.IsNullOrWhiteSpace( savedVersion ) ) {
+			return true;
+		}
+		var savedTimestamp = GetTimeLastChecked();
+		if( !savedTimestamp.HasValue || ( DateTimeOffset.UtcNow - savedTimestamp.Value ) > TimeSpan.FromDays( 1 ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	private static string? GetSavedLatestVersion() {
+		if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
+			return null;
+		}
+		return File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
+	}
+}
+
+internal record GithubRelease {
+	[JsonPropertyName( "tag_name" )]
+	public string? TagName { get; set; }
 }

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -23,7 +23,7 @@ internal class UpdateChecker {
 				DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
 					$"Upgrade now at {updateLocation}" );
 			}
-		} catch( Exception ex ) {
+		} catch( Exception ) {
 			// Give up and don't bother telling the user we couldn't check for updates
 		}
 	}

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -79,7 +79,7 @@ internal static class UpdateChecker {
 			VersionName = version,
 			TimeLastChecked = DateTimeOffset.UtcNow
 		};
-		var content = JsonSerializer.Serialize( cache, SourceGenerationContext.Default.UpdateCheckCache );
+		string content = JsonSerializer.Serialize( cache, SourceGenerationContext.Default.UpdateCheckCache );
 		var op = new FileStreamOptions {
 			Mode = FileMode.OpenOrCreate,
 			Access = FileAccess.ReadWrite,
@@ -97,7 +97,7 @@ internal static class UpdateChecker {
 			return null;
 		}
 
-		var content = File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
+		string content = File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
 		try {
 			return JsonSerializer.Deserialize( content, SourceGenerationContext.Default.UpdateCheckCache );
 		} catch( JsonException ) {

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -15,10 +15,10 @@ namespace D2L.Bmx {
 
 		public static async Task CheckForUpdatesAsync( BmxConfig config ) {
 			try {
-				var savedVersion = GetSavedLatestVersion();
+				var savedLatestVersion = GetSavedLatestVersion();
 				var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
 				var latestVersion = new Version( savedVersion ?? "0.0.0" );
-				if( ShouldFetchLatestVersion( savedVersion ) ) {
+				if( ShouldFetchLatestVersion( savedLatestVersion ) ) {
 					latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 				}
 

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Net.Http;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace D2L.Bmx {

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -4,42 +4,51 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace D2L.Bmx;
-internal static class UpdateChecker {
+internal static class UpdateChecker
+{
 
-	public static async Task CheckForUpdatesAsync( BmxConfig config ) {
-		try {
+	public static async Task CheckForUpdatesAsync(BmxConfig config)
+	{
+		try
+		{
 			var cachedVersion = GetUpdateCheckCache();
 			var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
-			var latestVersion = new Version( cachedVersion?.VersionName ?? "0.0.0" );
-			if( ShouldFetchLatestVersion( cachedVersion ) ) {
-				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
+			var latestVersion = new Version(cachedVersion?.VersionName ?? "0.0.0");
+			if (ShouldFetchLatestVersion(cachedVersion))
+			{
+				latestVersion = new Version(await GetLatestReleaseVersionAsync());
 			}
 
-			string updateLocation = string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase )
+			string updateLocation = string.Equals(config.Org, "d2l", StringComparison.OrdinalIgnoreCase)
 				? "https://bmx.d2l.dev"
 				: "https://github.com/Brightspace/bmx/releases/latest";
 
-			if( latestVersion > localVersion ) {
-				DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
-					$"Upgrade now at {updateLocation}" );
+			if (latestVersion > localVersion)
+			{
+				DisplayUpdateMessage($"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
+					$"Upgrade now at {updateLocation}");
 			}
-		} catch( Exception ) {
+		}
+		catch (Exception)
+		{
 			// Give up and don't bother telling the user we couldn't check for updates
 		}
 	}
 
-	private static void DisplayUpdateMessage( string message ) {
+	private static void DisplayUpdateMessage(string message)
+	{
 		var originalBackgroundColor = Console.BackgroundColor;
 		var originalForegroundColor = Console.ForegroundColor;
 
 		Console.BackgroundColor = ConsoleColor.Gray;
 		Console.ForegroundColor = ConsoleColor.Black;
 
-		string[] lines = message.Split( "\n" );
+		string[] lines = message.Split("\n");
 		int consoleWidth = Console.WindowWidth;
 
-		foreach( string line in lines ) {
-			Console.Error.Write( line.PadRight( consoleWidth ) );
+		foreach (string line in lines)
+		{
+			Console.Error.Write(line.PadRight(consoleWidth));
 			Console.Error.WriteLine();
 		}
 
@@ -49,12 +58,13 @@ internal static class UpdateChecker {
 		Console.Error.WriteLine();
 	}
 
-	private static async Task<string> GetLatestReleaseVersionAsync() {
+	private static async Task<string> GetLatestReleaseVersionAsync()
+	{
 		using var httpClient = new HttpClient();
-		httpClient.BaseAddress = new Uri( "https://api.github.com" );
-		httpClient.Timeout = TimeSpan.FromSeconds( 5 );
-		httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
-		var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
+		httpClient.BaseAddress = new Uri("https://api.github.com");
+		httpClient.Timeout = TimeSpan.FromSeconds(5);
+		httpClient.DefaultRequestHeaders.Add("User-Agent", "BMX");
+		var response = await httpClient.GetAsync("repos/Brightspace/bmx/releases/latest");
 		response.EnsureSuccessStatusCode();
 
 		await using var responseStream = await response.Content.ReadAsStreamAsync();
@@ -62,65 +72,80 @@ internal static class UpdateChecker {
 			responseStream,
 			SourceGenerationContext.Default.GithubRelease
 		);
-		string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
-		SaveLatestVersion( version );
+		string version = releaseData?.TagName?.Replace("v", "") ?? string.Empty;
+		SaveLatestVersion(version);
 		return version;
 	}
 
-	private static void SaveLatestVersion( string version ) {
-		if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
-			Directory.CreateDirectory( BmxPaths.BMX_DIR );
+	private static void SaveLatestVersion(string version)
+	{
+		if (!Directory.Exists(BmxPaths.BMX_DIR))
+		{
+			Directory.CreateDirectory(BmxPaths.BMX_DIR);
 		}
-		if( string.IsNullOrWhiteSpace( version ) ) {
+		if (string.IsNullOrWhiteSpace(version))
+		{
 			return;
 		}
-		var cache = new UpdateCheckCache {
+		var cache = new UpdateCheckCache
+		{
 			VersionName = version,
 			TimeLastChecked = DateTimeOffset.UtcNow
 		};
-		string content = JsonSerializer.Serialize( cache, SourceGenerationContext.Default.UpdateCheckCache );
-		var op = new FileStreamOptions {
+		string content = JsonSerializer.Serialize(cache, SourceGenerationContext.Default.UpdateCheckCache);
+		var op = new FileStreamOptions
+		{
 			Mode = FileMode.OpenOrCreate,
 			Access = FileAccess.ReadWrite,
 		};
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
-		using var fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );
-		using var writer = new StreamWriter( fs );
-		writer.Write( content );
+		using var fs = new FileStream(BmxPaths.UPDATE_CHECK_FILE_NAME, op);
+		using var writer = new StreamWriter(fs);
+		writer.Write(content);
 	}
 
-	private static UpdateCheckCache? GetUpdateCheckCache() {
-		if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
+	private static UpdateCheckCache? GetUpdateCheckCache()
+	{
+		if (!File.Exists(BmxPaths.UPDATE_CHECK_FILE_NAME))
+		{
 			return null;
 		}
 
-		string content = File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
-		try {
-			return JsonSerializer.Deserialize( content, SourceGenerationContext.Default.UpdateCheckCache );
-		} catch( JsonException ) {
+		string content = File.ReadAllText(BmxPaths.UPDATE_CHECK_FILE_NAME);
+		try
+		{
+			return JsonSerializer.Deserialize(content, SourceGenerationContext.Default.UpdateCheckCache);
+		}
+		catch (JsonException)
+		{
 			return null;
 		}
 	}
 
-	private static bool ShouldFetchLatestVersion( UpdateCheckCache? cache ) {
-		if( cache is null || string.IsNullOrWhiteSpace( cache.VersionName )
-			|| ( DateTimeOffset.UtcNow - cache.TimeLastChecked ) > TimeSpan.FromDays( 1 )
-			|| ( cache.TimeLastChecked > DateTimeOffset.UtcNow )
-		 ) {
+	private static bool ShouldFetchLatestVersion(UpdateCheckCache? cache)
+	{
+		if (cache is null || string.IsNullOrWhiteSpace(cache.VersionName)
+			|| (DateTimeOffset.UtcNow - cache.TimeLastChecked) > TimeSpan.FromDays(1)
+			|| (cache.TimeLastChecked > DateTimeOffset.UtcNow)
+		)
+		{
 			return true;
 		}
 		return false;
 	}
 }
 
-internal record GithubRelease {
-	[JsonPropertyName( "tag_name" )]
+internal record GithubRelease
+{
+	[JsonPropertyName("tag_name")]
 	public string? TagName { get; set; }
 }
 
-internal record UpdateCheckCache {
+internal record UpdateCheckCache
+{
 	public string? VersionName { get; set; }
 	public DateTimeOffset? TimeLastChecked { get; set; }
 }

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -50,10 +50,9 @@ internal class UpdateChecker {
 	}
 
 	private static async Task<string> GetLatestReleaseVersionAsync() {
-		using var httpClient = new HttpClient {
-			BaseAddress = new Uri( "https://api.github.com" ),
-			Timeout = TimeSpan.FromSeconds( 5 )
-		};
+		using var httpClient = new HttpClient();
+		httpClient.BaseAddress = new Uri( "https://api.github.com" );
+		httpClient.Timeout = TimeSpan.FromSeconds( 5 );
 		httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
 		var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
 		response.EnsureSuccessStatusCode();

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Net.Http;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace D2L.Bmx {
+	internal class UpdateChecker {
+
+		public static async Task CheckForUpdatesAsync( BmxConfig config ) {
+			try {
+				var savedVersion = GetSavedLatestVersion();
+				var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
+				var latestVersion = new Version( savedVersion ?? "0.0.0" );
+				if( ShouldFetchLatestVersion( savedVersion ) ) {
+					latestVersion = new Version( await GetLatestReleaseVersionAsync() );
+				}
+
+				var updateLocation = ( string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase ) )
+					? "https://bmx.d2l.dev"
+					: "https://github.com/Brightspace/bmx/releases/latest";
+
+				if( latestVersion > localVersion ) {
+					DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
+						$"Upgrade now at {updateLocation}" );
+				}
+			} catch( Exception ex ) {
+				// Give up and don't bother telling the user we couldn't check for updates
+				Console.Error.WriteLine( ex.ToString() );
+			}
+		}
+
+		private static void DisplayUpdateMessage( string message ) {
+			var originalBackgroundColor = Console.BackgroundColor;
+			var originalForegroundColor = Console.ForegroundColor;
+
+			Console.BackgroundColor = ConsoleColor.Gray;
+			Console.ForegroundColor = ConsoleColor.Black;
+
+			var lines = message.Split( "\n" );
+			int consoleWidth = Console.WindowWidth;
+
+			foreach( var line in lines ) {
+				Console.Error.Write( line.PadRight( consoleWidth ) );
+				Console.Error.WriteLine();
+			}
+
+			Console.BackgroundColor = originalBackgroundColor;
+			Console.ForegroundColor = originalForegroundColor;
+			Console.ResetColor();
+			Console.Error.WriteLine();
+		}
+
+		private static async Task<string> GetLatestReleaseVersionAsync() {
+			using var httpClient = new HttpClient {
+				BaseAddress = new Uri( "https://api.github.com" ),
+				Timeout = TimeSpan.FromSeconds( 5 )
+			};
+			httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
+			var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
+			response.EnsureSuccessStatusCode();
+
+			using var responseStream = await response.Content.ReadAsStreamAsync();
+			var releaseData = await JsonSerializer.DeserializeAsync(
+				responseStream,
+				SourceGenerationContext.Default.GithubRelease
+			);
+			string content = await response.Content.ReadAsStringAsync();
+			string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
+			SaveLatestVersion( version );
+			return version;
+		}
+
+		private static void SaveLatestVersion( string version ) {
+			if( string.IsNullOrWhiteSpace( version ) ) {
+				return;
+			}
+			if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
+				Directory.CreateDirectory( BmxPaths.BMX_DIR );
+			}
+			var op = new FileStreamOptions {
+				Mode = FileMode.OpenOrCreate,
+				Access = FileAccess.ReadWrite,
+			};
+			if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+				op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+			}
+			using FileStream fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );
+			using StreamWriter writer = new StreamWriter( fs );
+			writer.WriteLine( version );
+		}
+
+		private static DateTimeOffset? GetTimeLastChecked() {
+			if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
+				return null;
+			}
+			return File.GetLastWriteTimeUtc( BmxPaths.UPDATE_CHECK_FILE_NAME );
+		}
+
+		private static bool ShouldFetchLatestVersion( string? savedVersion ) {
+			if( string.IsNullOrWhiteSpace( savedVersion ) ) {
+				return true;
+			}
+			var savedTimestamp = GetTimeLastChecked();
+			if( !savedTimestamp.HasValue || ( DateTimeOffset.UtcNow - savedTimestamp.Value ) > TimeSpan.FromDays( 1 ) ) {
+				return true;
+			}
+			return false;
+		}
+
+		private static string? GetSavedLatestVersion() {
+			if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
+				return null;
+			}
+			return File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
+		}
+	}
+
+	internal record GithubRelease {
+		[JsonPropertyName( "tag_name" )]
+		public string? TagName { get; set; }
+	}
+}

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -12,7 +12,6 @@ internal static class UpdateChecker {
 			var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
 			var latestVersion = new Version( cachedVersion?.VersionName ?? "0.0.0" );
 			if( ShouldFetchLatestVersion( cachedVersion ) ) {
-				Console.Error.WriteLine( "Getting new version from github" );
 				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 			}
 

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -4,51 +4,42 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace D2L.Bmx;
-internal static class UpdateChecker
-{
+internal static class UpdateChecker {
 
-	public static async Task CheckForUpdatesAsync(BmxConfig config)
-	{
-		try
-		{
+	public static async Task CheckForUpdatesAsync( BmxConfig config ) {
+		try {
 			var cachedVersion = GetUpdateCheckCache();
 			var localVersion = Assembly.GetExecutingAssembly().GetName().Version;
-			var latestVersion = new Version(cachedVersion?.VersionName ?? "0.0.0");
-			if (ShouldFetchLatestVersion(cachedVersion))
-			{
-				latestVersion = new Version(await GetLatestReleaseVersionAsync());
+			var latestVersion = new Version( cachedVersion?.VersionName ?? "0.0.0" );
+			if( ShouldFetchLatestVersion( cachedVersion ) ) {
+				latestVersion = new Version( await GetLatestReleaseVersionAsync() );
 			}
 
-			string updateLocation = string.Equals(config.Org, "d2l", StringComparison.OrdinalIgnoreCase)
+			string updateLocation = string.Equals( config.Org, "d2l", StringComparison.OrdinalIgnoreCase )
 				? "https://bmx.d2l.dev"
 				: "https://github.com/Brightspace/bmx/releases/latest";
 
-			if (latestVersion > localVersion)
-			{
-				DisplayUpdateMessage($"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
-					$"Upgrade now at {updateLocation}");
+			if( latestVersion > localVersion ) {
+				DisplayUpdateMessage( $"A new BMX release is available: v{latestVersion} (current: v{localVersion})\n" +
+					$"Upgrade now at {updateLocation}" );
 			}
-		}
-		catch (Exception)
-		{
+		} catch( Exception ) {
 			// Give up and don't bother telling the user we couldn't check for updates
 		}
 	}
 
-	private static void DisplayUpdateMessage(string message)
-	{
+	private static void DisplayUpdateMessage( string message ) {
 		var originalBackgroundColor = Console.BackgroundColor;
 		var originalForegroundColor = Console.ForegroundColor;
 
 		Console.BackgroundColor = ConsoleColor.Gray;
 		Console.ForegroundColor = ConsoleColor.Black;
 
-		string[] lines = message.Split("\n");
+		string[] lines = message.Split( "\n" );
 		int consoleWidth = Console.WindowWidth;
 
-		foreach (string line in lines)
-		{
-			Console.Error.Write(line.PadRight(consoleWidth));
+		foreach( string line in lines ) {
+			Console.Error.Write( line.PadRight( consoleWidth ) );
 			Console.Error.WriteLine();
 		}
 
@@ -58,13 +49,12 @@ internal static class UpdateChecker
 		Console.Error.WriteLine();
 	}
 
-	private static async Task<string> GetLatestReleaseVersionAsync()
-	{
+	private static async Task<string> GetLatestReleaseVersionAsync() {
 		using var httpClient = new HttpClient();
-		httpClient.BaseAddress = new Uri("https://api.github.com");
-		httpClient.Timeout = TimeSpan.FromSeconds(5);
-		httpClient.DefaultRequestHeaders.Add("User-Agent", "BMX");
-		var response = await httpClient.GetAsync("repos/Brightspace/bmx/releases/latest");
+		httpClient.BaseAddress = new Uri( "https://api.github.com" );
+		httpClient.Timeout = TimeSpan.FromSeconds( 5 );
+		httpClient.DefaultRequestHeaders.Add( "User-Agent", "BMX" );
+		var response = await httpClient.GetAsync( "repos/Brightspace/bmx/releases/latest" );
 		response.EnsureSuccessStatusCode();
 
 		await using var responseStream = await response.Content.ReadAsStreamAsync();
@@ -72,80 +62,65 @@ internal static class UpdateChecker
 			responseStream,
 			SourceGenerationContext.Default.GithubRelease
 		);
-		string version = releaseData?.TagName?.Replace("v", "") ?? string.Empty;
-		SaveLatestVersion(version);
+		string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
+		SaveLatestVersion( version );
 		return version;
 	}
 
-	private static void SaveLatestVersion(string version)
-	{
-		if (!Directory.Exists(BmxPaths.BMX_DIR))
-		{
-			Directory.CreateDirectory(BmxPaths.BMX_DIR);
+	private static void SaveLatestVersion( string version ) {
+		if( !Directory.Exists( BmxPaths.BMX_DIR ) ) {
+			Directory.CreateDirectory( BmxPaths.BMX_DIR );
 		}
-		if (string.IsNullOrWhiteSpace(version))
-		{
+		if( string.IsNullOrWhiteSpace( version ) ) {
 			return;
 		}
-		var cache = new UpdateCheckCache
-		{
+		var cache = new UpdateCheckCache {
 			VersionName = version,
 			TimeLastChecked = DateTimeOffset.UtcNow
 		};
-		string content = JsonSerializer.Serialize(cache, SourceGenerationContext.Default.UpdateCheckCache);
-		var op = new FileStreamOptions
-		{
+		string content = JsonSerializer.Serialize( cache, SourceGenerationContext.Default.UpdateCheckCache );
+		var op = new FileStreamOptions {
 			Mode = FileMode.OpenOrCreate,
 			Access = FileAccess.ReadWrite,
 		};
-		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-		{
+		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
-		using var fs = new FileStream(BmxPaths.UPDATE_CHECK_FILE_NAME, op);
-		using var writer = new StreamWriter(fs);
-		writer.Write(content);
+		using var fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );
+		using var writer = new StreamWriter( fs );
+		writer.Write( content );
 	}
 
-	private static UpdateCheckCache? GetUpdateCheckCache()
-	{
-		if (!File.Exists(BmxPaths.UPDATE_CHECK_FILE_NAME))
-		{
+	private static UpdateCheckCache? GetUpdateCheckCache() {
+		if( !File.Exists( BmxPaths.UPDATE_CHECK_FILE_NAME ) ) {
 			return null;
 		}
 
-		string content = File.ReadAllText(BmxPaths.UPDATE_CHECK_FILE_NAME);
-		try
-		{
-			return JsonSerializer.Deserialize(content, SourceGenerationContext.Default.UpdateCheckCache);
-		}
-		catch (JsonException)
-		{
+		string content = File.ReadAllText( BmxPaths.UPDATE_CHECK_FILE_NAME );
+		try {
+			return JsonSerializer.Deserialize( content, SourceGenerationContext.Default.UpdateCheckCache );
+		} catch( JsonException ) {
 			return null;
 		}
 	}
 
-	private static bool ShouldFetchLatestVersion(UpdateCheckCache? cache)
-	{
-		if (cache is null || string.IsNullOrWhiteSpace(cache.VersionName)
-			|| (DateTimeOffset.UtcNow - cache.TimeLastChecked) > TimeSpan.FromDays(1)
-			|| (cache.TimeLastChecked > DateTimeOffset.UtcNow)
-		)
-		{
+	private static bool ShouldFetchLatestVersion( UpdateCheckCache? cache ) {
+		if( cache is null || string.IsNullOrWhiteSpace( cache.VersionName )
+			|| ( DateTimeOffset.UtcNow - cache.TimeLastChecked ) > TimeSpan.FromDays( 1 )
+			|| ( cache.TimeLastChecked > DateTimeOffset.UtcNow )
+		) {
 			return true;
 		}
 		return false;
 	}
 }
 
-internal record GithubRelease
-{
-	[JsonPropertyName("tag_name")]
+internal record GithubRelease {
+	[JsonPropertyName( "tag_name" )]
 	public string? TagName { get; set; }
 }
 
-internal record UpdateCheckCache
-{
+internal record UpdateCheckCache {
 	public string? VersionName { get; set; }
 	public DateTimeOffset? TimeLastChecked { get; set; }
 }

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -63,7 +63,6 @@ internal class UpdateChecker {
 			responseStream,
 			SourceGenerationContext.Default.GithubRelease
 		);
-		string content = await response.Content.ReadAsStringAsync();
 		string version = releaseData?.TagName?.Replace( "v", "" ) ?? string.Empty;
 		SaveLatestVersion( version );
 		return version;


### PR DESCRIPTION
### Why

Helps users know we have a new version out. This is a middle step in terms of having an update feature. It'd be good to keep all our users on the latest version.

We will ping github once every 24 hours and save the version tag it returned. So currently if there is a new version the user will see it every time they run BMX. I could change that to once every 24 hours though but this also maybe annoys them enough to want to upgrade lol

If the org is d2l we prompt them to visit out site with the install script. Users outside of d2l will get prompted to visit the github repo
![image](https://github.com/Brightspace/bmx/assets/90227099/63570694-4905-4fb7-8f5b-47dcb856f178)
![image](https://github.com/Brightspace/bmx/assets/90227099/f47e8966-3381-4256-a17a-e4f07d1f77bc)

related trello card: https://trello.com/b/r6wdvBry/vulcan-project-board
slack discussion: https://d2l.slack.com/archives/G4NV94H2A/p1693323866881979