### PR TITLE
Okta and AWS broader error handling

### DIFF
--- a/src/D2L.Bmx/Aws/AwsClient.cs
+++ b/src/D2L.Bmx/Aws/AwsClient.cs
@@ -28,11 +28,11 @@ internal class AwsClient( IAmazonSecurityTokenService stsClient ) : IAwsClient {
 				SecretAccessKey: authResp.Credentials.SecretAccessKey,
 				Expiration: authResp.Credentials.Expiration.ToUniversalTime()
 			);
-		} catch( Exception ex ) {
-			if( ex.Message == "The requested DurationSeconds exceeds the MaxSessionDuration set for this role." ) {
-				throw new BmxException( "Duration exceeds the MaxSessionDuration for this role. Lower it in config/parameter", ex );
-			}
-			throw new BmxException( "Error AWS failed to grab credentials", ex );
+		} catch( AmazonSecurityTokenServiceException ex ) when
+			( ex.Message == "The requested DurationSeconds exceeds the MaxSessionDuration set for this role." ) {
+			throw new BmxException( "Duration exceeds the MaxSessionDuration for this role. Lower it in config/parameter", ex );
+		} catch (Exception ex ) {
+			throw new BmxException( "Error getting credentials from AWS", ex );
 		}
 	}
 }

--- a/src/D2L.Bmx/Aws/AwsClient.cs
+++ b/src/D2L.Bmx/Aws/AwsClient.cs
@@ -13,18 +13,26 @@ internal class AwsClient( IAmazonSecurityTokenService stsClient ) : IAwsClient {
 		AwsRole role,
 		int durationInMinutes
 	) {
-		var authResp = await stsClient.AssumeRoleWithSAMLAsync( new AssumeRoleWithSAMLRequest {
-			PrincipalArn = role.PrincipalArn,
-			RoleArn = role.RoleArn,
-			SAMLAssertion = samlAssertion,
-			DurationSeconds = durationInMinutes * 60,
-		} );
 
-		return new AwsCredentials(
-			SessionToken: authResp.Credentials.SessionToken,
-			AccessKeyId: authResp.Credentials.AccessKeyId,
-			SecretAccessKey: authResp.Credentials.SecretAccessKey,
-			Expiration: authResp.Credentials.Expiration.ToUniversalTime()
-		);
+		try {
+			var authResp = await stsClient.AssumeRoleWithSAMLAsync( new AssumeRoleWithSAMLRequest {
+				PrincipalArn = role.PrincipalArn,
+				RoleArn = role.RoleArn,
+				SAMLAssertion = samlAssertion,
+				DurationSeconds = durationInMinutes * 60,
+			} );
+
+			return new AwsCredentials(
+				SessionToken: authResp.Credentials.SessionToken,
+				AccessKeyId: authResp.Credentials.AccessKeyId,
+				SecretAccessKey: authResp.Credentials.SecretAccessKey,
+				Expiration: authResp.Credentials.Expiration.ToUniversalTime()
+			);
+		} catch ( Exception ex ) {
+			if (ex.Message == "The requested DurationSeconds exceeds the MaxSessionDuration set for this role.") {
+				throw new BmxException( "Duration exceeds the MaxSessionDuration for this role. Lower it in config/parameter", ex );
+			}
+			throw new BmxException( "Error AWS failed to grab credentials", ex );
+		}
 	}
 }

--- a/src/D2L.Bmx/Aws/AwsClient.cs
+++ b/src/D2L.Bmx/Aws/AwsClient.cs
@@ -31,7 +31,7 @@ internal class AwsClient( IAmazonSecurityTokenService stsClient ) : IAwsClient {
 		} catch( AmazonSecurityTokenServiceException ex ) when
 			( ex.Message == "The requested DurationSeconds exceeds the MaxSessionDuration set for this role." ) {
 			throw new BmxException( "Duration exceeds the MaxSessionDuration for this role. Lower it in config/parameter", ex );
-		} catch (Exception ex ) {
+		} catch( Exception ex ) {
 			throw new BmxException( "Error getting credentials from AWS", ex );
 		}
 	}

--- a/src/D2L.Bmx/BmxException.cs
+++ b/src/D2L.Bmx/BmxException.cs
@@ -7,4 +7,5 @@ namespace D2L.Bmx;
 /// </remarks>
 internal class BmxException : Exception {
 	public BmxException( string message ) : base( message ) { }
+	public BmxException( string message, Exception ex ) : base( message, ex ) { }
 }

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -77,7 +77,7 @@ internal class OktaApi : IOktaApi {
 			throw new BmxException( "Okta API Authentication Response was not Success or MFA Required" );
 		} catch( Exception ex ) {
 			if ( ex is BmxException ) {
-				throw new BmxException( "Okta authentication failed. Check if ./bmx/config org and user is correct", ex );
+				throw new BmxException( "Okta authentication failed. Check if org, user and password is correct", ex );
 			}
 			throw new BmxException( "Error authenticating to Okta" , ex);
 		}

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -130,6 +130,8 @@ internal class OktaApi : IOktaApi {
 				new CreateSessionRequest( sessionToken ),
 				SourceGenerationContext.Default.CreateSessionRequest );
 
+			resp.EnsureSuccessStatusCode();
+
 			var session = await JsonSerializer.DeserializeAsync(
 				await resp.Content.ReadAsStreamAsync(),
 				SourceGenerationContext.Default.OktaSession );

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -76,6 +76,9 @@ internal class OktaApi : IOktaApi {
 			}
 			throw new BmxException( "Okta API Authentication Response was not Success or MFA Required" );
 		} catch( Exception ex ) {
+			if ( ex is BmxException ) {
+				throw new BmxException( "Okta authentication failed. Check if ./bmx/config org and user is correct", ex );
+			}
 			throw new BmxException( "Error authenticating to Okta" , ex);
 		}
 	}

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -55,7 +55,7 @@ internal class OktaApi : IOktaApi {
 				"authn",
 				new AuthenticateRequest( username, password ),
 				SourceGenerationContext.Default.AuthenticateRequest );
-		} catch ( Exception ex ) {
+		} catch( Exception ex ) {
 			throw new BmxException( "Okta authentication request failed. Try checking for a stable connection.", ex );
 		}
 		var authnResponse = await JsonSerializer.DeserializeAsync(
@@ -118,7 +118,7 @@ internal class OktaApi : IOktaApi {
 			return new AuthenticateResponse.Success( authnResponse.SessionToken );
 		}
 		throw new BmxException( "Error verifying Okta MFA challenge response." );
-		
+
 	}
 
 	async Task<OktaSession> IOktaApi.CreateSessionAsync( string sessionToken ) {
@@ -150,7 +150,7 @@ internal class OktaApi : IOktaApi {
 
 		return apps?.Where( app => app.AppName == "amazon_aws" ).ToArray()
 				?? throw new BmxException( "Error retrieving AWS accounts from Okta." );
-	
+
 	}
 
 	async Task<string> IOktaApi.GetPageAsync( string samlLoginUrl ) {

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -164,7 +164,7 @@ internal class OktaApi : IOktaApi {
 				"users/me/appLinks",
 				SourceGenerationContext.Default.OktaAppArray );
 		} catch( Exception ex ) {
-			throw new BmxException( "Request to retrieving AWS accounts from Okta.", ex );
+			throw new BmxException( "Request to retrieve AWS accounts from Okta failed.", ex );
 		}
 
 		return apps?.Where( app => app.AppName == "amazon_aws" ).ToArray()

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -64,7 +64,7 @@ internal class OktaApi : IOktaApi {
 			authnResponse = await JsonSerializer.DeserializeAsync(
 				await resp.Content.ReadAsStreamAsync(),
 				SourceGenerationContext.Default.AuthenticateResponseRaw );
-		} catch (Exception ex) {
+		} catch( Exception ex ) {
 			throw new BmxException( "Okta authentication failed. Okta returned an invalid response", ex );
 		}
 
@@ -123,7 +123,7 @@ internal class OktaApi : IOktaApi {
 			authnResponse = await JsonSerializer.DeserializeAsync(
 					await resp.Content.ReadAsStreamAsync(),
 					SourceGenerationContext.Default.AuthenticateResponseRaw );
-		} catch ( Exception ex ) {
+		} catch( Exception ex ) {
 			throw new BmxException( "Error verifying MFA with Okta. Okta returned an invalid response", ex );
 		}
 

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -164,7 +164,7 @@ internal class OktaApi : IOktaApi {
 				"users/me/appLinks",
 				SourceGenerationContext.Default.OktaAppArray );
 		} catch( Exception ex ) {
-			throw new BmxException( "Error retrieving AWS accounts from Okta.", ex );
+			throw new BmxException( "Request to retrieving AWS accounts from Okta.", ex );
 		}
 
 		return apps?.Where( app => app.AppName == "amazon_aws" ).ToArray()


### PR DESCRIPTION
### Why
Adding more error handling to network calls to avoid the general "BMX exited with unexpected internal error" error.