### PR TITLE
Update labeler.yml for actions/labeler@v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,22 +1,29 @@
 language/csharp:
-  - "**/*.cs"
-  - "**/*.csproj"
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.cs'
+          - '**/*.csproj'
 language/js:
-  - "**/*.js"
-  - "**/package.json*"
-  - "**/*.ts"
-  - "**/*.vue"
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.js'
+          - '**/package.json*'
+          - '**/*.ts'
+          - '**/*.vue'
 language/sql:
-  - "**/*.sql"
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.sql'
 language/terraform:
-  - "**/*.tf"
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.tf'
 language/powershell:
-  - "**/*.ps1"
-  - "**/*.psm1"
-
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.ps1'
+          - '**/*.psm1'
 area/github-actions:
-  - ".github/workflows/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**


### PR DESCRIPTION
Brightspace/third-party-actions@actions/labeler is [updated][1] to actions/labeler@v5 with [breaking changes][2].

[1]: https://github.com/Brightspace/third-party-actions-config/pull/1101
[2]: https://github.com/actions/labeler?tab=readme-ov-file#breaking-changes-in-v5
