### PR TITLE
display current version more accurately

### DIFF
--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -199,7 +199,7 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 
 var updateCommand = new Command( "update", "Updates BMX to the latest version" );
 updateCommand.SetHandler( ( InvocationContext context ) => {
-	var handler = new UpdateHandler( new GitHubClient() );
+	var handler = new UpdateHandler( new GitHubClient(), new VersionProvider() );
 	return handler.HandleAsync();
 } );
 
@@ -241,7 +241,7 @@ return await new CommandLineBuilder( rootCommand )
 			}
 
 			if( context.ParseResult.CommandResult.Command != updateCommand ) {
-				var updateChecker = new UpdateChecker( new GitHubClient() );
+				var updateChecker = new UpdateChecker( new GitHubClient(), new VersionProvider() );
 				await updateChecker.CheckForUpdatesAsync();
 			}
 

--- a/src/D2L.Bmx/VersionProvider.cs
+++ b/src/D2L.Bmx/VersionProvider.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+
+namespace D2L.Bmx;
+
+internal interface IVersionProvider {
+	Version? GetAssemblyVersion();
+	string? GetInformationalVersion();
+}
+
+internal class VersionProvider : IVersionProvider {
+	private readonly Assembly _currentAssembly = Assembly.GetExecutingAssembly();
+
+	public Version? GetAssemblyVersion() {
+		return _currentAssembly.GetName().Version;
+	}
+
+	public string? GetInformationalVersion() {
+		return _currentAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+	}
+}


### PR DESCRIPTION
This should rarely if ever happen for regular users, but...
if someone was using a preview release (later than "latest") and ran "bmx update", they would've seen something like:

> You already have the latest version 3.0.0.0

Problems:
* "3.0.0.0" is the "latest" release as indicated by GitHub, not the actual version the user is using, which should look like "3.1.0-preview"
* We never display the four part version format anywhere else.

This change makes this message displays the actual version the user currently has, and uses the "informational version" to align with what users would see with "bmx --version".