### PR TITLE
add '--use-credential-process' to write command

### DIFF
--- a/src/D2L.Bmx/AwsCredsCreator.cs
+++ b/src/D2L.Bmx/AwsCredsCreator.cs
@@ -3,13 +3,20 @@ using D2L.Bmx.Okta.Models;
 
 namespace D2L.Bmx;
 
+internal record AwsCredentialsInfo(
+	string Account,
+	string Role,
+	int Duration,
+	AwsCredentials Credentials
+);
+
 internal class AwsCredsCreator(
 	IAwsClient awsClient,
 	IConsolePrompter consolePrompter,
 	IAwsCredentialCache awsCredentialCache,
 	BmxConfig config
 ) {
-	public async Task<AwsCredentials> CreateAwsCredsAsync(
+	public async Task<AwsCredentialsInfo> CreateAwsCredsAsync(
 		AuthenticatedOktaApi oktaApi,
 		string? account,
 		string? role,
@@ -50,7 +57,11 @@ internal class AwsCredsCreator(
 			);
 
 			if( cachedCredentials is not null ) {
-				return cachedCredentials;
+				return new(
+					Account: account,
+					Role: role,
+					Duration: duration.Value,
+					Credentials: cachedCredentials );
 			}
 		}
 
@@ -92,7 +103,11 @@ internal class AwsCredsCreator(
 			);
 
 			if( cachedCredentials is not null ) {
-				return cachedCredentials;
+				return new(
+					Account: account,
+					Role: role,
+					Duration: duration.Value,
+					Credentials: cachedCredentials );
 			}
 		}
 
@@ -117,6 +132,10 @@ internal class AwsCredsCreator(
 			);
 		}
 
-		return credentials;
+		return new(
+			Account: account,
+			Role: role,
+			Duration: duration.Value,
+			Credentials: credentials );
 	}
 }

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -8,8 +8,14 @@ internal static class ParameterDescriptions {
 	public const string Role = "AWS role name";
 	public const string Duration = "AWS session duration in minutes";
 	public const string Profile = "AWS profile name";
-	public const string Output = "Custom path to the AWS credentials file";
+	public const string Output =
+		"Custom path to the AWS credentials file, or the AWS config file if '--use-credential-process' is supplied";
 	public const string Format = "Output format of AWS credentials";
 	public const string NonInteractive = "Run non-interactively without showing any prompts";
-	public const string CacheAwsCredentials = "Enables Cache for AWS tokens";
+	public const string CacheAwsCredentials =
+		"Enables Cache for AWS tokens. Implied if '--use-credential-process' is supplied";
+	public const string UseCredentialProcess = """
+		Write BMX command to AWS profile, so that AWS tools & SDKs using the profile will source credentials from BMX.
+		See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.
+		""";
 }

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -22,14 +22,14 @@ internal class PrintHandler(
 			nonInteractive: nonInteractive,
 			ignoreCache: false
 		);
-		var awsCreds = await awsCredsCreator.CreateAwsCredsAsync(
+		var awsCreds = ( await awsCredsCreator.CreateAwsCredsAsync(
 			oktaApi: oktaApi,
 			account: account,
 			role: role,
 			duration: duration,
 			nonInteractive: nonInteractive,
 			cache: cacheAwsCredentials
-		);
+		) ).Credentials;
 
 		if( string.Equals( format, PrintFormat.Bash, StringComparison.OrdinalIgnoreCase ) ) {
 			PrintBash( awsCreds );

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -153,6 +153,9 @@ var outputOption = new Option<string>(
 var profileOption = new Option<string>(
 	name: "--profile",
 	description: ParameterDescriptions.Profile );
+var useCredentialProcessOption = new Option<bool>(
+	name: "--use-credential-process",
+	description: ParameterDescriptions.UseCredentialProcess );
 
 var writeCommand = new Command( "write", "Write AWS credentials to the credentials file" ) {
 	accountOption,
@@ -164,6 +167,7 @@ var writeCommand = new Command( "write", "Write AWS credentials to the credentia
 	userOption,
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
+	useCredentialProcessOption
 };
 
 writeCommand.SetHandler( ( InvocationContext context ) => {
@@ -193,7 +197,8 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 		nonInteractive: context.ParseResult.GetValueForOption( nonInteractiveOption ),
 		output: context.ParseResult.GetValueForOption( outputOption ),
 		profile: context.ParseResult.GetValueForOption( profileOption ),
-		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption )
+		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption ),
+		useCredentialProcess: context.ParseResult.GetValueForOption( useCredentialProcessOption )
 	);
 } );
 

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -167,7 +167,7 @@ var writeCommand = new Command( "write", "Write AWS credentials to the credentia
 	userOption,
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
-	useCredentialProcessOption
+	useCredentialProcessOption,
 };
 
 writeCommand.SetHandler( ( InvocationContext context ) => {


### PR DESCRIPTION
Make it easier for people to start using BMX in `credential_process`, and reduce user errors.

https://d2l.slack.com/archives/G4P099831/p1705333949277619