### PR TITLE
wipes profile section when bmx write --use-credential-process is ran

### DIFF
--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -70,10 +70,12 @@ internal class WriteHandler(
 			if( !data.Sections.ContainsSection( sectionName ) ) {
 				data.Sections.AddSection( sectionName );
 			}
-			var defaultCredentialsFile = parser.ReadFile( SharedCredentialsFile.DefaultFilePath );
-			if (defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
-				defaultCredentialsFile.Sections.RemoveSection( profile );
-				parser.WriteFile(SharedCredentialsFile.DefaultFilePath, defaultCredentialsFile);
+			if (File.Exists(SharedCredentialsFile.DefaultFilePath)) {
+				var defaultCredentialsFile = parser.ReadFile( SharedCredentialsFile.DefaultFilePath );
+				if ( defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
+					defaultCredentialsFile.Sections.RemoveSection( profile );
+					parser.WriteFile( SharedCredentialsFile.DefaultFilePath, defaultCredentialsFile );
+				}
 			}
 			data[sectionName]["credential_process"] =
 				"bmx print --format json --cache --non-interactive"

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -70,6 +70,11 @@ internal class WriteHandler(
 			if( !data.Sections.ContainsSection( sectionName ) ) {
 				data.Sections.AddSection( sectionName );
 			}
+			var defaultCredentialsFile = parser.ReadFile( SharedCredentialsFile.DefaultFilePath );
+			if (defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
+				defaultCredentialsFile.Sections.RemoveSection( profile );
+				parser.WriteFile(SharedCredentialsFile.DefaultFilePath, defaultCredentialsFile);
+			}
 			data[sectionName]["credential_process"] =
 				"bmx print --format json --cache --non-interactive"
 				+ $" --org \"{oktaApi.Org}\""

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -70,7 +70,7 @@ internal class WriteHandler(
 			if( !data.Sections.ContainsSection( sectionName ) ) {
 				data.Sections.AddSection( sectionName );
 			}
-			if (File.Exists(SharedCredentialsFile.DefaultFilePath)) {
+			if ( File.Exists( SharedCredentialsFile.DefaultFilePath ) ) {
 				var defaultCredentialsFile = parser.ReadFile( SharedCredentialsFile.DefaultFilePath );
 				if ( defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
 					defaultCredentialsFile.Sections.RemoveSection( profile );

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -70,9 +70,9 @@ internal class WriteHandler(
 			if( !data.Sections.ContainsSection( sectionName ) ) {
 				data.Sections.AddSection( sectionName );
 			}
-			if ( File.Exists( SharedCredentialsFile.DefaultFilePath ) ) {
+			if( File.Exists( SharedCredentialsFile.DefaultFilePath ) ) {
 				var defaultCredentialsFile = parser.ReadFile( SharedCredentialsFile.DefaultFilePath );
-				if ( defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
+				if( defaultCredentialsFile.Sections.ContainsSection( profile ) ) {
 					defaultCredentialsFile.Sections.RemoveSection( profile );
 					parser.WriteFile( SharedCredentialsFile.DefaultFilePath, defaultCredentialsFile );
 				}


### PR DESCRIPTION
### Why
If there's a profile with the same name in the credentials and config file, it will default to the credentials file, so you will eventually get invalid credentials


### Ticket
https://desire2learn.atlassian.net/browse/VUL-329
