### PR TITLE
display okta user and org in password prompt / failed auth error message

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -8,7 +8,7 @@ internal interface IConsolePrompter {
 	string PromptOrg( bool allowEmptyInput );
 	string PromptProfile();
 	string PromptUser( bool allowEmptyInput );
-	string PromptPassword();
+	string PromptPassword( string user, string org );
 	int? PromptDuration();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
@@ -63,7 +63,7 @@ internal class ConsolePrompter : IConsolePrompter {
 		return user;
 	}
 
-	string IConsolePrompter.PromptPassword() {
+	string IConsolePrompter.PromptPassword( string user, string org ) {
 		Func<char> readKey;
 		if( IS_WINDOWS ) {
 			// On Windows, Console.ReadKey calls native console API, and will fail without a console attached
@@ -84,7 +84,8 @@ internal class ConsolePrompter : IConsolePrompter {
 			readKey = () => (char)_stdinReader.Read();
 		}
 
-		Console.Error.Write( $"{ParameterDescriptions.Password}: " );
+		string passwordPrompt = string.Format( ParameterDescriptions.Password, user, org );
+		Console.Error.Write( $"{passwordPrompt}: " );
 
 		string? originalTerminalSettings = null;
 		try {

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -84,8 +84,9 @@ internal class ConsolePrompter : IConsolePrompter {
 			readKey = () => (char)_stdinReader.Read();
 		}
 
-		string passwordPrompt = string.Format( ParameterDescriptions.Password, user, org );
-		Console.Error.Write( $"{passwordPrompt}: " );
+		Console.Error.WriteLine( $"{ParameterDescriptions.Org}: {org}" );
+		Console.Error.WriteLine( $"{ParameterDescriptions.User}: {user}" );
+		Console.Error.Write( $"{ParameterDescriptions.Password}: " );
 
 		string? originalTerminalSettings = null;
 		try {

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -88,7 +88,7 @@ internal class OktaApi : IOktaApi {
 		}
 		throw new BmxException(
 			$"Okta authentication for user '{username}' in org '{organization}' failed."
-				+ " Check if org, user and password is correct" );
+				+ " Check if org, user, and password is correct" );
 	}
 
 	async Task IOktaApi.IssueMfaChallengeAsync( string stateToken, string factorId ) {

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -87,7 +87,7 @@ internal class OktaApi : IOktaApi {
 			);
 		}
 
-		string org = _organization is not null ? _organization : "unknown";
+		string org = _organization ?? "unknown";
 		throw new BmxException(
 			$"Okta authentication for user '{username}' in org '{org}'"
 				+ "failed. Check if org, user, and password is correct" );

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -90,7 +90,7 @@ internal class OktaApi : IOktaApi {
 		string org = _organization is not null ? _organization : "unknown";
 		throw new BmxException(
 			$"Okta authentication for user '{username}' in org '{org}'"
-				 + "failed. Check if org, user, and password is correct" );
+				+ "failed. Check if org, user, and password is correct" );
 	}
 
 	async Task IOktaApi.IssueMfaChallengeAsync( string stateToken, string factorId ) {

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -87,7 +87,7 @@ internal class OktaApi : IOktaApi {
 			);
 		}
 		throw new BmxException(
-			$"Okta authentication for user '{username}' and org '{organization}' failed."
+			$"Okta authentication for user '{username}' in org '{organization}' failed."
 				+ " Check if org, user and password is correct" );
 	}
 

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -23,7 +23,7 @@ internal interface IOktaApi {
 internal class OktaApi : IOktaApi {
 	private readonly CookieContainer _cookieContainer;
 	private readonly HttpClient _httpClient;
-	private string organization = string.Empty;
+	private string? _organization;
 
 	public OktaApi() {
 		_cookieContainer = new CookieContainer();
@@ -34,7 +34,7 @@ internal class OktaApi : IOktaApi {
 	}
 
 	void IOktaApi.SetOrganization( string organization ) {
-		this.organization = organization;
+		_organization = organization;
 		if( !organization.Contains( '.' ) ) {
 			_httpClient.BaseAddress = new Uri( $"https://{organization}.okta.com/api/v1/" );
 		} else {
@@ -86,9 +86,11 @@ internal class OktaApi : IOktaApi {
 				authnResponse.Embedded.Factors
 			);
 		}
+
+		string org = _organization is not null ? _organization : "unknown";
 		throw new BmxException(
-			$"Okta authentication for user '{username}' in org '{organization}' failed."
-				+ " Check if org, user, and password is correct" );
+			$"Okta authentication for user '{username}' in org '{org}'"
+				 + "failed. Check if org, user, and password is correct" );
 	}
 
 	async Task IOktaApi.IssueMfaChallengeAsync( string stateToken, string factorId ) {

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -86,7 +86,7 @@ internal class OktaAuthenticator(
 			return new AuthenticatedOktaApi( Org: org, User: user, Api: oktaApi );
 		}
 
-		throw new BmxException( $"Okta authentication failed using username {user} in org {org}" );
+		throw new BmxException( "Okta authentication failed" );
 	}
 
 	private bool TryAuthenticateFromCache(

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -50,7 +50,7 @@ internal class OktaAuthenticator(
 			throw new BmxException( "Okta authentication failed. Please run `bmx login` first." );
 		}
 
-		string password = consolePrompter.PromptPassword();
+		string password = consolePrompter.PromptPassword( user, org );
 
 		var authnResponse = await oktaApi.AuthenticateAsync( user, password );
 
@@ -86,7 +86,7 @@ internal class OktaAuthenticator(
 			return new AuthenticatedOktaApi( Org: org, User: user, Api: oktaApi );
 		}
 
-		throw new BmxException( "Okta authentication failed" );
+		throw new BmxException( $"Okta authentication failed using username {user} in org {org}" );
 	}
 
 	private bool TryAuthenticateFromCache(

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -3,7 +3,7 @@ namespace D2L.Bmx;
 internal static class ParameterDescriptions {
 	public const string Org = "Okta org short name or domain name";
 	public const string User = "Okta username";
-	public const string Password = "Okta password";
+	public const string Password = "Okta password for username {0} in org {1}";
 	public const string Account = "AWS account name";
 	public const string Role = "AWS role name";
 	public const string Duration = "AWS session duration in minutes";

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -3,7 +3,7 @@ namespace D2L.Bmx;
 internal static class ParameterDescriptions {
 	public const string Org = "Okta org short name or domain name";
 	public const string User = "Okta username";
-	public const string Password = "Okta password for username '{0}' in org '{1}'";
+	public const string Password = "Okta password";
 	public const string Account = "AWS account name";
 	public const string Role = "AWS role name";
 	public const string Duration = "AWS session duration in minutes";

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -3,7 +3,7 @@ namespace D2L.Bmx;
 internal static class ParameterDescriptions {
 	public const string Org = "Okta org short name or domain name";
 	public const string User = "Okta username";
-	public const string Password = "Okta password for username {0} in org {1}";
+	public const string Password = "Okta password for username '{0}' in org '{1}'";
 	public const string Account = "AWS account name";
 	public const string Role = "AWS role name";
 	public const string Duration = "AWS session duration in minutes";


### PR DESCRIPTION
### Why

Potential for the config file to have bad user / org values and it's not immediately obvious to the user that those could be the reason for their okta auth failing. This can happen with our internal install script when running wsl and the user gets set to 'root' in the config file.

![image](https://github.com/Brightspace/bmx/assets/90227099/0af4fa92-4efd-4a89-ad4f-973ce4bd83a0)

### Ticket

VUL-330