### PR TITLE
Remove qoutes from invoke via AWS Credential Process

### DIFF
--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -79,10 +79,10 @@ internal class WriteHandler(
 			}
 			data[sectionName]["credential_process"] =
 				"bmx print --format json --cache --non-interactive"
-				+ $" --org \"{oktaApi.Org}\""
-				+ $" --user \"{oktaApi.User}\""
-				+ $" --account \"{awsCredsInfo.Account}\""
-				+ $" --role \"{awsCredsInfo.Role}\""
+				+ $" --org {oktaApi.Org}"
+				+ $" --user {oktaApi.User}"
+				+ $" --account {awsCredsInfo.Account}"
+				+ $" --role {awsCredsInfo.Role}"
 				+ $" --duration {awsCredsInfo.Duration}";
 		} else {
 			if( !data.Sections.ContainsSection( profile ) ) {


### PR DESCRIPTION
### Why

@cfbao noticed that the various AWS SDK's handle invoking applications used by credential_process differently. In the case of the Go SDK that includes, invoking BMX verbatim, including qoutes and all.

There isn't a need to quote any of these fields to handle white spaces (username, okta subdomain, aws role name, or assume duration etc...)

