### PR TITLE
write: update config file section with same name if no cred process flag

### DIFF
--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -86,23 +86,23 @@ internal class WriteHandler(
 				+ $" --duration {awsCredsInfo.Duration}";
 		} else {
 			if( File.Exists( SharedCredentialsFile.DefaultConfigFilePath ) ) {
-				string profileName = $"profile {profile}";
+				string sectionName = $"profile {profile}";
 				var defaultConfigFile = parser.ReadFile( SharedCredentialsFile.DefaultConfigFilePath );
-				if( defaultConfigFile.Sections.ContainsSection( profileName )
-					&& defaultConfigFile[profileName].ContainsKey( "credential_process" ) ) {
+				if( defaultConfigFile.Sections.ContainsSection( sectionName )
+					&& defaultConfigFile[sectionName].ContainsKey( "credential_process" ) ) {
 
-					if( defaultConfigFile[profileName].Count == 1 ) {
-						defaultConfigFile.Sections.RemoveSection( profileName );
+					if( defaultConfigFile[sectionName].Count == 1 ) {
+						defaultConfigFile.Sections.RemoveSection( sectionName );
 					} else {
-						defaultConfigFile[profileName].RemoveKey( "credential_process" );
+						defaultConfigFile[sectionName].RemoveKey( "credential_process" );
 					}
 					parser.WriteFile( SharedCredentialsFile.DefaultConfigFilePath, defaultConfigFile );
 					Console.WriteLine(
-						"""
-						An existing profile with the same name using the `credential_process` setting was found in the default config file.
-						The setting has been removed, and static credentials will be used for the profile.
-						To continue using non-static credentials, rerun the command with the --use-credential-process flag.
-						"""
+"""
+An existing profile with the same name using the `credential_process` setting was found in the default config file.
+The setting has been removed, and static credentials will be used for the profile.
+To continue using non-static credentials, rerun the command with the --use-credential-process flag.
+"""
 					);
 				}
 			}

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -85,6 +85,27 @@ internal class WriteHandler(
 				+ $" --role {awsCredsInfo.Role}"
 				+ $" --duration {awsCredsInfo.Duration}";
 		} else {
+			if( File.Exists( SharedCredentialsFile.DefaultConfigFilePath ) ) {
+				string profileName = $"profile {profile}";
+				var defaultConfigFile = parser.ReadFile( SharedCredentialsFile.DefaultConfigFilePath );
+				if( defaultConfigFile.Sections.ContainsSection( profileName )
+					&& defaultConfigFile[profileName].ContainsKey( "credential_process" ) ) {
+
+					if( defaultConfigFile[profileName].Count == 1 ) {
+						defaultConfigFile.Sections.RemoveSection( profileName );
+					} else {
+						defaultConfigFile[profileName].RemoveKey( "credential_process" );
+					}
+					parser.WriteFile( SharedCredentialsFile.DefaultConfigFilePath, defaultConfigFile );
+					Console.WriteLine(
+						"""
+						An existing profile with the same name using the `credential_process` key was found in the default config file.
+						The key has been removed, and static credentials will be used for the profile.
+						To continue using non-static credentials, rerun the command with the --use-credential-process flag.
+						"""
+					);
+				}
+			}
 			if( !data.Sections.ContainsSection( profile ) ) {
 				data.Sections.AddSection( profile );
 			}

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -99,8 +99,8 @@ internal class WriteHandler(
 					parser.WriteFile( SharedCredentialsFile.DefaultConfigFilePath, defaultConfigFile );
 					Console.WriteLine(
 						"""
-						An existing profile with the same name using the `credential_process` key was found in the default config file.
-						The key has been removed, and static credentials will be used for the profile.
+						An existing profile with the same name using the `credential_process` setting was found in the default config file.
+						The setting has been removed, and static credentials will be used for the profile.
 						To continue using non-static credentials, rerun the command with the --use-credential-process flag.
 						"""
 					);


### PR DESCRIPTION
### Why

Default credentials file takes priority over the default config which is where we store profiles using `credential_process`. If someone had an existing profile in config file and then runs `bmx write`, creds will be stored into the default credentials file making the existing one useless. We should remove the existing key in the config file so there is no confusion.

`credential_process` is the better way for majority of people but there are some scenarios where it's not supported. So we are leaving some information to the user that it is no longer being used. Just in case they unintentionally ran write without the flag. Not going with a prompt to confirm because that could break existing scripts

### Ticket

VUL-385