### PR TITLE
De-serialize Security Question MFA to different type

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -130,12 +130,12 @@ internal class ConsolePrompter : IConsolePrompter {
 		}
 
 		if( mfaOptions.Length == 1 ) {
-			Console.Error.WriteLine( $"MFA method: {mfaOptions[0].Provider}-{mfaOptions[0].FactorType}" );
+			Console.Error.WriteLine( $"MFA method: {mfaOptions[0].Provider}-{mfaOptions[0].FactorName}" );
 			return mfaOptions[0];
 		}
 
 		for( int i = 0; i < mfaOptions.Length; i++ ) {
-			Console.Error.WriteLine( $"[{i + 1}] {mfaOptions[i].Provider}-{mfaOptions[i].FactorType}" );
+			Console.Error.WriteLine( $"[{i + 1}] {mfaOptions[i].Provider}-{mfaOptions[i].FactorName}" );
 		}
 		Console.Error.Write( "Select an available MFA option: " );
 		if( !int.TryParse( _stdinReader.ReadLine(), out int index ) || index > mfaOptions.Length || index < 1 ) {

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.5.24306.7" />
   </ItemGroup>
 
 </Project>

--- a/src/D2L.Bmx/JsonSerializerContext.cs
+++ b/src/D2L.Bmx/JsonSerializerContext.cs
@@ -5,7 +5,10 @@ using D2L.Bmx.Okta.Models;
 
 namespace D2L.Bmx;
 
-[JsonSourceGenerationOptions( PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase )]
+[JsonSourceGenerationOptions(
+	PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+	AllowOutOfOrderMetadataProperties = true
+)]
 [JsonSerializable( typeof( AuthenticateRequest ) )]
 [JsonSerializable( typeof( IssueMfaChallengeRequest ) )]
 [JsonSerializable( typeof( VerifyMfaChallengeResponseRequest ) )]

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -38,7 +38,8 @@ internal record OktaMfaFactor {
 	public required string Provider { get; set; }
 	public required string VendorName { get; set; }
 
-	public const string FactorType = "unknown";
+	public const string UnsupportedMfaFactor = "unknown";
+
 	[JsonIgnore]
 	public virtual string FactorName => "unknown";
 	[JsonIgnore]

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -21,17 +21,68 @@ internal record AuthenticateResponseEmbedded(
 	OktaMfaFactor[]? Factors
 );
 
+[JsonPolymorphic(
+	TypeDiscriminatorPropertyName = "factorType",
+	IgnoreUnrecognizedTypeDiscriminators = true
+)]
+[JsonDerivedType( typeof( OktaMfaQuestionFactor ), "question" )]
+[JsonDerivedType( typeof( OktaMfaHardwareToken ), "token" )]
+[JsonDerivedType( typeof( OktaMfaHardwareTokenFactor ), "token:hardware" )]
+[JsonDerivedType( typeof( OktaMfaSoftwareTotpFactor ), "token:software:totp" )]
+[JsonDerivedType( typeof( OktaMfaHotpFactor ), "token:hotp" )]
+[JsonDerivedType( typeof( OktaMfaSmsFactor ), "sms" )]
+[JsonDerivedType( typeof( OktaMfaCallFactor ), "call" )]
+[JsonDerivedType( typeof( OktaMfaEmailFactor ), "email" )]
+internal record OktaMfaFactor {
+	public required string Id { get; set; }
+	public required string Provider { get; set; }
+	public required string VendorName { get; set; }
+
+	[JsonIgnore]
+	public virtual string FactorName => "Unknown";
+	[JsonIgnore]
+	public virtual bool RequireChallengeIssue => false;
+}
+
+internal record OktaMfaQuestionFactor() : OktaMfaFactor() {
+	public override string FactorName => "Security Question";
+	public required OktaMfaQuestionProfile Profile { get; set; }
+}
+
 internal record OktaMfaQuestionProfile(
 	string QuestionText
 );
 
-internal record OktaMfaFactor(
-	string Id,
-	string FactorType,
-	string Provider,
-	string VendorName,
-	OktaMfaQuestionProfile Profile
-);
+internal record OktaMfaHardwareToken() : OktaMfaFactor {
+	public override string FactorName => "Hardware Token";
+}
+
+internal record OktaMfaHardwareTokenFactor() : OktaMfaFactor {
+	public override string FactorName => "Hardware TOTP";
+}
+
+internal record OktaMfaSoftwareTotpFactor() : OktaMfaFactor {
+	public override string FactorName => "Software TOTP";
+}
+
+internal record OktaMfaHotpFactor() : OktaMfaFactor {
+	public override string FactorName => "HOTP";
+}
+
+internal record OktaMfaSmsFactor() : OktaMfaFactor {
+	public override string FactorName => "SMS";
+	public override bool RequireChallengeIssue => true;
+}
+
+internal record OktaMfaCallFactor() : OktaMfaFactor {
+	public override string FactorName => "Call";
+	public override bool RequireChallengeIssue => true;
+}
+
+internal record OktaMfaEmailFactor() : OktaMfaFactor {
+	public override string FactorName => "Email";
+	public override bool RequireChallengeIssue => true;
+}
 
 internal enum AuthenticationStatus {
 	UNKNOWN,

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -38,8 +38,9 @@ internal record OktaMfaFactor {
 	public required string Provider { get; set; }
 	public required string VendorName { get; set; }
 
+	public const string FactorType = "unknown";
 	[JsonIgnore]
-	public virtual string FactorName => "Unknown";
+	public virtual string FactorName => "unknown";
 	[JsonIgnore]
 	public virtual bool RequireChallengeIssue => false;
 }

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -25,14 +25,14 @@ internal record AuthenticateResponseEmbedded(
 	TypeDiscriminatorPropertyName = "factorType",
 	IgnoreUnrecognizedTypeDiscriminators = true
 )]
-[JsonDerivedType( typeof( OktaMfaQuestionFactor ), "question" )]
-[JsonDerivedType( typeof( OktaMfaHardwareToken ), "token" )]
-[JsonDerivedType( typeof( OktaMfaHardwareTokenFactor ), "token:hardware" )]
-[JsonDerivedType( typeof( OktaMfaSoftwareTotpFactor ), "token:software:totp" )]
-[JsonDerivedType( typeof( OktaMfaHotpFactor ), "token:hotp" )]
-[JsonDerivedType( typeof( OktaMfaSmsFactor ), "sms" )]
-[JsonDerivedType( typeof( OktaMfaCallFactor ), "call" )]
-[JsonDerivedType( typeof( OktaMfaEmailFactor ), "email" )]
+[JsonDerivedType( typeof( OktaMfaQuestionFactor ), OktaMfaQuestionFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaTokenFactor ), OktaMfaTokenFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaHardwareTokenFactor ), OktaMfaHardwareTokenFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaSoftwareTotpFactor ), OktaMfaSoftwareTotpFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaHotpFactor ), OktaMfaHotpFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaSmsFactor ), OktaMfaSmsFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaCallFactor ), OktaMfaCallFactor.FactorType )]
+[JsonDerivedType( typeof( OktaMfaEmailFactor ), OktaMfaEmailFactor.FactorType )]
 internal record OktaMfaFactor {
 	public required string Id { get; set; }
 	public required string Provider { get; set; }
@@ -47,6 +47,7 @@ internal record OktaMfaFactor {
 internal record OktaMfaQuestionFactor(
 	OktaMfaQuestionProfile Profile
 ) : OktaMfaFactor {
+	public const string FactorType = "question";
 	public override string FactorName => "Security Question";
 }
 
@@ -54,33 +55,40 @@ internal record OktaMfaQuestionProfile(
 	string QuestionText
 );
 
-internal record OktaMfaHardwareToken() : OktaMfaFactor {
-	public override string FactorName => "Hardware Token";
+internal record OktaMfaTokenFactor() : OktaMfaFactor {
+	public const string FactorType = "token";
+	public override string FactorName => "Token";
 }
 
 internal record OktaMfaHardwareTokenFactor() : OktaMfaFactor {
-	public override string FactorName => "Hardware TOTP";
+	public const string FactorType = "token:hardware";
+	public override string FactorName => "Hardware Token";
 }
 
 internal record OktaMfaSoftwareTotpFactor() : OktaMfaFactor {
+	public const string FactorType = "token:software:totp";
 	public override string FactorName => "Software TOTP";
 }
 
 internal record OktaMfaHotpFactor() : OktaMfaFactor {
+	public const string FactorType = "token:hotp";
 	public override string FactorName => "HOTP";
 }
 
 internal record OktaMfaSmsFactor() : OktaMfaFactor {
+	public const string FactorType = "sms";
 	public override string FactorName => "SMS";
 	public override bool RequireChallengeIssue => true;
 }
 
 internal record OktaMfaCallFactor() : OktaMfaFactor {
+	public const string FactorType = "call";
 	public override string FactorName => "Call";
 	public override bool RequireChallengeIssue => true;
 }
 
 internal record OktaMfaEmailFactor() : OktaMfaFactor {
+	public const string FactorType = "email";
 	public override string FactorName => "Email";
 	public override bool RequireChallengeIssue => true;
 }

--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -44,9 +44,10 @@ internal record OktaMfaFactor {
 	public virtual bool RequireChallengeIssue => false;
 }
 
-internal record OktaMfaQuestionFactor() : OktaMfaFactor() {
+internal record OktaMfaQuestionFactor(
+	OktaMfaQuestionProfile Profile
+) : OktaMfaFactor {
 	public override string FactorName => "Security Question";
-	public required OktaMfaQuestionProfile Profile { get; set; }
 }
 
 internal record OktaMfaQuestionProfile(

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -57,7 +57,7 @@ internal class OktaAuthenticator(
 		if( authnResponse is AuthenticateResponse.MfaRequired mfaInfo ) {
 			OktaMfaFactor mfaFactor = consolePrompter.SelectMfa( mfaInfo.Factors );
 
-			if( mfaFactor.FactorName == OktaMfaFactor.FactorType ) {
+			if( mfaFactor.FactorName == OktaMfaFactor.UnsupportedMfaFactor ) {
 				throw new BmxException( "Selected MFA not supported by BMX" );
 			}
 

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -57,18 +57,18 @@ internal class OktaAuthenticator(
 		if( authnResponse is AuthenticateResponse.MfaRequired mfaInfo ) {
 			OktaMfaFactor mfaFactor = consolePrompter.SelectMfa( mfaInfo.Factors );
 
-			if( !IsMfaFactorTypeSupported( mfaFactor.FactorType ) ) {
+			if( mfaFactor.FactorName == "Unknown" ) {
 				throw new BmxException( "Selected MFA not supported by BMX" );
 			}
 
 			// TODO: Handle retry
-			if( mfaFactor.FactorType is "sms" or "call" or "email" ) {
+			if( mfaFactor.RequireChallengeIssue ) {
 				await oktaApi.IssueMfaChallengeAsync( mfaInfo.StateToken, mfaFactor.Id );
 			}
 
 			string mfaResponse = consolePrompter.GetMfaResponse(
-				mfaFactor.FactorType == "question" ? mfaFactor.Profile.QuestionText : "PassCode",
-				mfaFactor.FactorType == "question"
+				mfaFactor is OktaMfaQuestionFactor questionFactor ? questionFactor.Profile.QuestionText : "PassCode",
+				mfaFactor is OktaMfaQuestionFactor // Security question factor is a static value
 			);
 
 			authnResponse = await oktaApi.VerifyMfaChallengeResponseAsync( mfaInfo.StateToken, mfaFactor.Id, mfaResponse );
@@ -133,17 +133,4 @@ internal class OktaAuthenticator(
 		var currTime = DateTimeOffset.Now;
 		return sourceCache.Where( session => session.ExpiresAt > currTime ).ToList();
 	}
-
-	private static bool IsMfaFactorTypeSupported( string mfaFactorType ) {
-		return mfaFactorType is
-			"call"
-			or "email"
-			or "question"
-			or "sms"
-			or "token:hardware"
-			or "token:hotp"
-			or "token:software:totp"
-			or "token";
-	}
-
 }

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -57,7 +57,7 @@ internal class OktaAuthenticator(
 		if( authnResponse is AuthenticateResponse.MfaRequired mfaInfo ) {
 			OktaMfaFactor mfaFactor = consolePrompter.SelectMfa( mfaInfo.Factors );
 
-			if( mfaFactor.FactorName == "Unknown" ) {
+			if( mfaFactor.FactorName == OktaMfaFactor.FactorType ) {
 				throw new BmxException( "Selected MFA not supported by BMX" );
 			}
 


### PR DESCRIPTION
### Why

With .NET 9 we can use properties aside from the first in JSON to do type discrimination (in this case using ``factorType`` in the API).

So we can use it de-serialize the different properties in Factor's Profile section (in this case we only care about QuestionText for the Security Question factor).


### Ticket

N/A