### PR TITLE
update to .NET 9

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: set up dotnet
         uses: Brightspace/third-party-actions@actions/setup-dotnet
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: format
         id: format

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
       - name: set up .NET
         uses: Brightspace/third-party-actions@actions/setup-dotnet
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: publish
         shell: pwsh

--- a/Dockerfile.al2
+++ b/Dockerfile.al2
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/share/dotnet && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 RUN wget https://dot.net/v1/dotnet-install.sh \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet
+    && ./dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet
 
 WORKDIR /source
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/share/dotnet && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 RUN wget https://dot.net/v1/dotnet-install.sh \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet
+    && ./dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet
 
 WORKDIR /source
 

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>bmx</AssemblyName>
     <PublishAot>true</PublishAot>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RootNamespace>D2L.Bmx</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -15,7 +15,6 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.5.24306.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Why

The trimmer seems to have trouble preserving the correct type when we reference a package that provides types included in the runtime.

Specifically, we're using [a System.Text.Json preview package](https://www.nuget.org/packages/System.Text.Json/9.0.0-preview.5.24306.7) to utilize the new `AllowOutOfOrderMetadataProperties` feature, but the trimmer isn't keeping relevant new members in Json Serialization types (even if explicitly instructed to by a trimmer root descriptor file), resulting in runtime errors.

Updating to .NET 9 solves this problem, as we no longer need the preview package, and the types/members we need are in the runtime.

This is likely a trimmer bug that we should report to https://github.com/dotnet/runtime/issues.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-403