### PR TITLE
don't print duplicate org & user info

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -8,7 +8,7 @@ internal interface IConsolePrompter {
 	string PromptOrg( bool allowEmptyInput );
 	string PromptProfile();
 	string PromptUser( bool allowEmptyInput );
-	string PromptPassword( string user, string org );
+	string PromptPassword();
 	int? PromptDuration();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
@@ -63,9 +63,7 @@ internal class ConsolePrompter : IConsolePrompter {
 		return user;
 	}
 
-	string IConsolePrompter.PromptPassword( string user, string org ) {
-		Console.Error.WriteLine( $"{ParameterDescriptions.Org}: {org}" );
-		Console.Error.WriteLine( $"{ParameterDescriptions.User}: {user}" );
+	string IConsolePrompter.PromptPassword() {
 		return GetMaskedInput( $"{ParameterDescriptions.Password}: " );
 	}
 

--- a/src/D2L.Bmx/Okta/OktaApi.cs
+++ b/src/D2L.Bmx/Okta/OktaApi.cs
@@ -88,9 +88,10 @@ internal class OktaApi : IOktaApi {
 		}
 
 		string org = _organization ?? "unknown";
-		throw new BmxException(
-			$"Okta authentication for user '{username}' in org '{org}'"
-				+ "failed. Check if org, user, and password is correct" );
+		throw new BmxException( $"""
+			Okta authentication for user '{username}' in org '{org}' failed.
+			Check if org, user, and password is correct
+			""" );
 	}
 
 	async Task IOktaApi.IssueMfaChallengeAsync( string stateToken, string factorId ) {

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -1,7 +1,7 @@
 namespace D2L.Bmx;
 
 internal static class ParameterDescriptions {
-	public const string Org = "Okta org short name or domain name";
+	public const string Org = "Okta org or domain name";
 	public const string User = "Okta username";
 	public const string Password = "Okta password";
 	public const string Account = "AWS account name";


### PR DESCRIPTION
### Why

This is niche, but glaring once you notice it:
If Okta org and/or username aren't specified in BMX config file or provided via command line args, BMX will prompt the user to enter the info, and immediately print the same info again:

![Screenshot 2024-07-20 092346](https://github.com/user-attachments/assets/4b24afe9-c159-4767-bcc3-20ccd632548c)

A good solution isn't exactly obvious or straightforward as one might think.

A few options:

1. Keep the behaviour as is:
  Simple, but looks bad in niche cases

1. Print org or user at the time of password prompt, but only if there was no org or user prompt:
   Simple, but the order can be inconsistent in certain cases.
   E.g. if only org is prompted, we'd get this:
   ```
   Okta org name or domain name: d2l
   Okta username: cbao
   Okta password: ***
   ```
   if only user is prompted, we'd get this:
   ```
   Okta username: cbao
   Okta org name or domain name: d2l
   Okta password: ***
   ```
   Also, it'd be nice if people can see the Okta org when they're being prompted for their Okta username

1. Always print both Okta org and user (and potentially also AWS account name & role name) when not entered via a prompt
  Simple and good interactive UX, but BMX will become a lot more chatty than before, which some users might find jarring? Possibly considered a breaking change for some scripts?

1. Print both Okta org and user exactly once and always in the same order if and only if one or more of org, user or password is prompted.
  Most consistent with BMX 3.1.0- behaviour. Very self-consistent too. However, the implementation logic will be complex and unintuitive.
  This PR implements this option to showcase its complexity.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-403