### PR TITLE
print parameter value if and only if provided via CLI arg or config

### DIFF
--- a/src/D2L.Bmx/AwsCredsCreator.cs
+++ b/src/D2L.Bmx/AwsCredsCreator.cs
@@ -13,6 +13,7 @@ internal record AwsCredentialsInfo(
 internal class AwsCredsCreator(
 	IAwsClient awsClient,
 	IConsolePrompter consolePrompter,
+	IConsoleWriter consoleWriter,
 	IAwsCredentialCache awsCredentialCache,
 	BmxConfig config
 ) {
@@ -30,12 +31,22 @@ internal class AwsCredsCreator(
 			);
 		}
 
+		var accountSource = ParameterSource.CliArg;
 		if( string.IsNullOrEmpty( account ) && !string.IsNullOrEmpty( config.Account ) ) {
 			account = config.Account;
+			accountSource = ParameterSource.Config;
+		}
+		if( !string.IsNullOrEmpty( account ) && !nonInteractive ) {
+			consoleWriter.WriteParameter( ParameterDescriptions.Account, account, accountSource );
 		}
 
+		var roleSource = ParameterSource.CliArg;
 		if( string.IsNullOrEmpty( role ) && !string.IsNullOrEmpty( config.Role ) ) {
 			role = config.Role;
+			roleSource = ParameterSource.Config;
+		}
+		if( !string.IsNullOrEmpty( role ) && !nonInteractive ) {
+			consoleWriter.WriteParameter( ParameterDescriptions.Role, role, roleSource );
 		}
 
 		if( duration is null or 0 ) {

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -8,7 +8,7 @@ internal interface IConsolePrompter {
 	string PromptOrg( bool allowEmptyInput );
 	string PromptProfile();
 	string PromptUser( bool allowEmptyInput );
-	string PromptPassword( string user, string org );
+	string PromptPassword();
 	int? PromptDuration();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
@@ -63,9 +63,7 @@ internal class ConsolePrompter : IConsolePrompter {
 		return user;
 	}
 
-	string IConsolePrompter.PromptPassword( string user, string org ) {
-		Console.Error.WriteLine( $"{ParameterDescriptions.Org}: {org}" );
-		Console.Error.WriteLine( $"{ParameterDescriptions.User}: {user}" );
+	string IConsolePrompter.PromptPassword() {
 		return GetMaskedInput( $"{ParameterDescriptions.Password}: " );
 	}
 

--- a/src/D2L.Bmx/ConsoleWriter.cs
+++ b/src/D2L.Bmx/ConsoleWriter.cs
@@ -1,0 +1,17 @@
+namespace D2L.Bmx;
+
+internal interface IConsoleWriter {
+	void WriteParameter( string description, string value, ParameterSource source );
+}
+
+internal class ConsoleWriter : IConsoleWriter {
+	void IConsoleWriter.WriteParameter( string description, string value, ParameterSource source ) {
+		Console.ResetColor();
+		Console.Error.Write( $"{description}: " );
+		Console.ForegroundColor = ConsoleColor.Cyan;
+		Console.Error.Write( value );
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.Error.WriteLine( $" (from {source})" );
+		Console.ResetColor();
+	}
+}

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -1,7 +1,7 @@
 namespace D2L.Bmx;
 
 internal static class ParameterDescriptions {
-	public const string Org = "Okta org short name or domain name";
+	public const string Org = "Okta org or domain name";
 	public const string User = "Okta username";
 	public const string Password = "Okta password";
 	public const string Account = "AWS account name";

--- a/src/D2L.Bmx/ParameterSource.cs
+++ b/src/D2L.Bmx/ParameterSource.cs
@@ -1,0 +1,14 @@
+namespace D2L.Bmx;
+
+internal record ParameterSource {
+	public string Description { get; init; }
+
+	private ParameterSource( string description ) {
+		Description = description;
+	}
+
+	public static ParameterSource CliArg => new( "command line argument" );
+	public static ParameterSource Config => new( "config file" );
+
+	public override string ToString() => Description;
+}

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -29,6 +29,7 @@ loginCommand.SetHandler( ( InvocationContext context ) => {
 		new OktaApi(),
 		new OktaSessionStorage(),
 		new ConsolePrompter(),
+		new ConsoleWriter(),
 		config
 	) );
 	return handler.HandleAsync(
@@ -121,16 +122,19 @@ var printCommand = new Command( "print", "Print AWS credentials" ) {
 
 printCommand.SetHandler( ( InvocationContext context ) => {
 	var consolePrompter = new ConsolePrompter();
+	var consoleWriter = new ConsoleWriter();
 	var config = new BmxConfigProvider( new FileIniDataParser() ).GetConfiguration();
 	var handler = new PrintHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
 			new OktaSessionStorage(),
 			consolePrompter,
+			consoleWriter,
 			config ),
 		new AwsCredsCreator(
 			new AwsClient( new AmazonSecurityTokenServiceClient( new AnonymousAWSCredentials() ) ),
 			consolePrompter,
+			consoleWriter,
 			new AwsCredsCache(),
 			config )
 	);
@@ -172,16 +176,19 @@ var writeCommand = new Command( "write", "Write AWS credentials to the credentia
 
 writeCommand.SetHandler( ( InvocationContext context ) => {
 	var consolePrompter = new ConsolePrompter();
+	var consoleWriter = new ConsoleWriter();
 	var config = new BmxConfigProvider( new FileIniDataParser() ).GetConfiguration();
 	var handler = new WriteHandler(
 		new OktaAuthenticator(
 			new OktaApi(),
 			new OktaSessionStorage(),
 			consolePrompter,
+			consoleWriter,
 			config ),
 		new AwsCredsCreator(
 			new AwsClient( new AmazonSecurityTokenServiceClient( new AnonymousAWSCredentials() ) ),
 			consolePrompter,
+			consoleWriter,
 			new AwsCredsCache(),
 			config ),
 		consolePrompter,

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -192,6 +192,7 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 			new AwsCredsCache(),
 			config ),
 		consolePrompter,
+		consoleWriter,
 		config,
 		new FileIniDataParser()
 	);


### PR DESCRIPTION
### Why

Follow up to https://github.com/Brightspace/bmx/pull/463
As per Zoom discussion, BMX will always print parameter value & source if and only if it's provided via CLI args or config file.

I also made it colourful for legibility. The line seems too long and crowded without these colours.
![image](https://github.com/user-attachments/assets/27461fa6-2b9a-48a1-946e-5db92d244235)

The colours don't work if stdout is redirected, which is typical when using `bmx print`. I know why this is happening. Will try to fix in a separate PR.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-423