### PR TITLE
print duration when provided via config file or CLI arg

### DIFF
--- a/src/D2L.Bmx/AwsCredsCreator.cs
+++ b/src/D2L.Bmx/AwsCredsCreator.cs
@@ -49,12 +49,18 @@ internal class AwsCredsCreator(
 			consoleWriter.WriteParameter( ParameterDescriptions.Role, role, roleSource );
 		}
 
+		var durationSource = ParameterSource.CliArg;
 		if( duration is null or 0 ) {
 			if( config.Duration is not ( null or 0 ) ) {
 				duration = config.Duration;
+				durationSource = ParameterSource.Config;
 			} else {
 				duration = 60;
+				durationSource = ParameterSource.BuiltInDefault;
 			}
+		}
+		if( durationSource != ParameterSource.BuiltInDefault ) {
+			consoleWriter.WriteParameter( ParameterDescriptions.Duration, duration.Value.ToString(), durationSource );
 		}
 
 		// if using cache, avoid calling Okta at all if possible

--- a/src/D2L.Bmx/ParameterSource.cs
+++ b/src/D2L.Bmx/ParameterSource.cs
@@ -9,6 +9,7 @@ internal record ParameterSource {
 
 	public static ParameterSource CliArg => new( "command line argument" );
 	public static ParameterSource Config => new( "config file" );
+	public static ParameterSource BuiltInDefault => new( "built-in default" );
 
 	public override string ToString() => Description;
 }


### PR DESCRIPTION
Because it's not a required parameter, I didn't think to include it in the new parameter printing behaviour.
However, on second thought, this is one of the most common sources of problems users have - they have long duration defined in some config file that isn't compatible with the account/role that they want to use.

https://desire2learn.atlassian.net/browse/VUL-423