### PR TITLE
replace RuntimeInformation.IsOSPlatform with OperatingSystem.Is*

### DIFF
--- a/src/D2L.Bmx/Aws/AwsCredsCache.cs
+++ b/src/D2L.Bmx/Aws/AwsCredsCache.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace D2L.Bmx.Aws;
@@ -14,7 +13,7 @@ internal class AwsCredsCache : IAwsCredentialCache {
 			Mode = FileMode.Create,
 			Access = FileAccess.Write,
 		};
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( !OperatingSystem.IsWindows() ) {
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
 		using var writer = new StreamWriter( path, op );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using IniParser;
 using IniParser.Model;
 namespace D2L.Bmx;
@@ -60,7 +59,7 @@ internal class BmxConfigProvider(
 			Mode = FileMode.OpenOrCreate,
 			Access = FileAccess.ReadWrite,
 		};
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( !OperatingSystem.IsWindows() ) {
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
 		using var fs = new FileStream( BmxPaths.CONFIG_FILE_NAME, op );

--- a/src/D2L.Bmx/Okta/OktaSessionStorage.cs
+++ b/src/D2L.Bmx/Okta/OktaSessionStorage.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using D2L.Bmx.Okta.Models;
 
@@ -37,7 +36,7 @@ internal class OktaSessionStorage : IOktaSessionStorage {
 			Mode = FileMode.Create,
 			Access = FileAccess.Write,
 		};
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( !OperatingSystem.IsWindows() ) {
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
 		using var writer = new StreamWriter( path, op );

--- a/src/D2L.Bmx/UpdateChecker.cs
+++ b/src/D2L.Bmx/UpdateChecker.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using D2L.Bmx.GitHub;
 
@@ -51,7 +50,7 @@ internal class UpdateChecker( IGitHubClient github, IVersionProvider versionProv
 			Mode = FileMode.OpenOrCreate,
 			Access = FileAccess.ReadWrite,
 		};
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( !OperatingSystem.IsWindows() ) {
 			op.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 		}
 		using var fs = new FileStream( BmxPaths.UPDATE_CHECK_FILE_NAME, op );

--- a/src/D2L.Bmx/UpdateHandler.cs
+++ b/src/D2L.Bmx/UpdateHandler.cs
@@ -1,6 +1,5 @@
 using System.Formats.Tar;
 using System.IO.Compression;
-using System.Runtime.InteropServices;
 using D2L.Bmx.GitHub;
 
 namespace D2L.Bmx;
@@ -101,19 +100,19 @@ internal class UpdateHandler( IGitHubClient github, IVersionProvider versionProv
 	}
 
 	private static BmxFileInfo GetFileInfo() {
-		if( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( OperatingSystem.IsWindows() ) {
 			return new BmxFileInfo(
 				ArchiveName: "bmx-win-x64.zip",
 				ExeName: "bmx.exe",
 				ArchiveType: ArchiveType.Zip
 			);
-		} else if( RuntimeInformation.IsOSPlatform( OSPlatform.OSX ) ) {
+		} else if( OperatingSystem.IsMacOS() ) {
 			return new BmxFileInfo(
 				ArchiveName: "bmx-osx-x64.tar.gz",
 				ExeName: "bmx",
 				ArchiveType: ArchiveType.TarGzip
 			);
-		} else if( RuntimeInformation.IsOSPlatform( OSPlatform.Linux ) ) {
+		} else if( OperatingSystem.IsLinux() ) {
 			return new BmxFileInfo(
 				ArchiveName: "bmx-linux-x64.tar.gz",
 				ExeName: "bmx",

--- a/src/D2L.Bmx/VirtualTerminal.cs
+++ b/src/D2L.Bmx/VirtualTerminal.cs
@@ -12,7 +12,7 @@ internal static partial class VirtualTerminal {
 
 	// https://learn.microsoft.com/en-us/windows/console/classic-vs-vt
 	public static bool TryEnableOnStderr() {
-		if( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ) {
+		if( !OperatingSystem.IsWindows() ) {
 			// POSIX systems all support ANSI escape codes
 			return true;
 		}


### PR DESCRIPTION
`OperatingSystem.Is*` methods are newer and more efficient. They are basically constants.
A very rough check suggests that, with these new methods, the native AOT trimmer/linker can even eliminate OS-specific dead code!

See https://github.com/dotnet/aspnetcore/issues/24653