### PR TITLE
don't print duration if --non-interactive supplied

### DIFF
--- a/src/D2L.Bmx/AwsCredsCreator.cs
+++ b/src/D2L.Bmx/AwsCredsCreator.cs
@@ -59,7 +59,7 @@ internal class AwsCredsCreator(
 				durationSource = ParameterSource.BuiltInDefault;
 			}
 		}
-		if( durationSource != ParameterSource.BuiltInDefault ) {
+		if( durationSource != ParameterSource.BuiltInDefault && !nonInteractive ) {
 			consoleWriter.WriteParameter( ParameterDescriptions.Duration, duration.Value.ToString(), durationSource );
 		}
 


### PR DESCRIPTION
Not a big deal and shouldn't affect any practical use cases, but at least for consistency sake, duration should be like other parameters - don't print if the `--non-interactive` flag is supplied on the command line.