### PR TITLE
make Okta API client stateless

### DIFF
--- a/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
+++ b/src/D2L.Bmx/Okta/Models/AuthenticateResponse.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json.Serialization;
 
 namespace D2L.Bmx.Okta.Models;
@@ -5,6 +6,7 @@ namespace D2L.Bmx.Okta.Models;
 internal abstract record AuthenticateResponse {
 	public record MfaRequired( string StateToken, OktaMfaFactor[] Factors ) : AuthenticateResponse;
 	public record Success( string SessionToken ) : AuthenticateResponse;
+	public record Failure( HttpStatusCode StatusCode ) : AuthenticateResponse;
 }
 
 internal record AuthenticateResponseRaw(

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -16,14 +16,14 @@ internal class PrintHandler(
 		string? format,
 		bool cacheAwsCredentials
 	) {
-		var oktaApi = await oktaAuth.AuthenticateAsync(
+		var oktaContext = await oktaAuth.AuthenticateAsync(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
 			ignoreCache: false
 		);
 		var awsCreds = ( await awsCredsCreator.CreateAwsCredsAsync(
-			oktaApi: oktaApi,
+			okta: oktaContext,
 			account: account,
 			role: role,
 			duration: duration,

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -27,7 +27,7 @@ loginCommand.SetHandler( ( InvocationContext context ) => {
 	var consoleWriter = new ConsoleWriter();
 	var config = new BmxConfigProvider( new FileIniDataParser(), consoleWriter ).GetConfiguration();
 	var handler = new LoginHandler( new OktaAuthenticator(
-		new OktaApi(),
+		new OktaClientFactory(),
 		new OktaSessionStorage(),
 		new ConsolePrompter(),
 		consoleWriter,
@@ -127,7 +127,7 @@ printCommand.SetHandler( ( InvocationContext context ) => {
 	var config = new BmxConfigProvider( new FileIniDataParser(), consoleWriter ).GetConfiguration();
 	var handler = new PrintHandler(
 		new OktaAuthenticator(
-			new OktaApi(),
+			new OktaClientFactory(),
 			new OktaSessionStorage(),
 			consolePrompter,
 			consoleWriter,
@@ -181,7 +181,7 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 	var config = new BmxConfigProvider( new FileIniDataParser(), consoleWriter ).GetConfiguration();
 	var handler = new WriteHandler(
 		new OktaAuthenticator(
-			new OktaApi(),
+			new OktaClientFactory(),
 			new OktaSessionStorage(),
 			consolePrompter,
 			consoleWriter,

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -31,14 +31,14 @@ internal class WriteHandler(
 	) {
 		cacheAwsCredentials = cacheAwsCredentials || useCredentialProcess;
 
-		var oktaApi = await oktaAuth.AuthenticateAsync(
+		var oktaContext = await oktaAuth.AuthenticateAsync(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
 			ignoreCache: false
 		);
 		var awsCredsInfo = await awsCredsCreator.CreateAwsCredsAsync(
-			oktaApi: oktaApi,
+			okta: oktaContext,
 			account: account,
 			role: role,
 			duration: duration,
@@ -98,8 +98,8 @@ internal class WriteHandler(
 			RemoveCredentialProviderSettings( awsConfig[sectionName], out _ );
 			awsConfig[sectionName]["credential_process"] =
 				"bmx print --format json --cache --non-interactive"
-				+ $" --org {oktaApi.Org}"
-				+ $" --user {oktaApi.User}"
+				+ $" --org {oktaContext.Org}"
+				+ $" --user {oktaContext.User}"
 				+ $" --account {awsCredsInfo.Account}"
 				+ $" --role {awsCredsInfo.Role}"
 				+ $" --duration {awsCredsInfo.Duration}";


### PR DESCRIPTION
### Why

The original `OktaApi` class is stateful, i.e. it matters in what order you call its methods. This makes it hard to use & error prone.

I've split up its methods and different states into three different classes, so each one is stateless and has a smaller scope.
When & how you can transition from one state (unauthed) to another (authed) is also enforced via the API contract (rather than  relying on knowledge of its underlying behaviour).

### Ticket

https://desire2learn.atlassian.net/browse/VUL-104
