### PR TITLE
trim each line when printing update reminder

### DIFF
--- a/src/D2L.Bmx/ConsoleWriter.cs
+++ b/src/D2L.Bmx/ConsoleWriter.cs
@@ -35,7 +35,9 @@ internal class ConsoleWriter : IConsoleWriter {
 			Console.Error.WriteLine();
 			return;
 		}
-		string[] lines = text.Split( '\n' );
+		// Trim entries so we don't have extra `\r` characters on Windows.
+		// Splitting on `Environment.NewLine` isn't as safe, because we might also use `\n` on Windows.
+		string[] lines = text.Split( '\n', StringSplitOptions.TrimEntries );
 		int maxLineLength = lines.Max( l => l.Length );
 		foreach( string line in lines ) {
 			string paddedLine = line.PadRight( maxLineLength );


### PR DESCRIPTION
### Why

The update reminder's background area is misaligned on Windows:
![image](https://github.com/user-attachments/assets/e0dccf6d-419d-4a1f-ba27-ac33cdbd562d)

This is because we didn't account for `\r` on Windows.
Still a mystery why this only happens with GitHub Actions' build but not with our local builds. Regardless, this fix works with both.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-447