### PR TITLE
ci: fix build uploading after adding arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,28 +123,26 @@ jobs:
           if ($env:PLATFORM -eq 'win') {
             Push-Location "x64"
             Compress-Archive -Path "bmx.exe" -DestinationPath "bmx-win-x64.zip"
+            gh release upload "$env:RELEASE_ID" "bmx-win-x64.zip"
             Pop-Location
 
             Push-Location "arm64"
             Compress-Archive -Path "bmx.exe" -DestinationPath "bmx-win-arm64.zip"
-            Pop-Location
-
-            gh release upload "$env:RELEASE_ID" "bmx-win-x64.zip"
             gh release upload "$env:RELEASE_ID" "bmx-win-arm64.zip"
+            Pop-Location
           } elseif ($env:PLATFORM -eq 'osx') {
             chmod +x "./x64/bmx"
             chmod +x "./arm64/bmx"
 
             Push-Location "x64"
             tar -czvf "bmx-osx-x64.tar.gz" "bmx"
+            gh release upload "$env:RELEASE_ID" "bmx-osx-x64.tar.gz"
             Pop-Location
 
             Push-Location "arm64"
             tar -czvf "bmx-osx-arm64.tar.gz" "bmx"
-            Pop-Location
-
-            gh release upload "$env:RELEASE_ID" "bmx-osx-x64.tar.gz"
             gh release upload "$env:RELEASE_ID" "bmx-osx-arm64.tar.gz"
+            Pop-Location
           }
 
   build_docker:


### PR DESCRIPTION
### Why

Couldn't find the archive files because they were being created in those folders for each architecture

Made another test release to make sure it was working https://github.com/Brightspace/bmx/releases/tag/v3.1.3

### Ticket

VUL-71
