### PR TITLE
reword user-facing messages to say "passwordless"

### DIFF
--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -20,5 +20,5 @@ internal static class ParameterDescriptions {
 		""";
 
 	public const string ExperimentalBypassBrowserSecurity
-		= "Disable Chromium sandbox when automatically signing into Okta";
+		= "Disable Chromium sandbox when using Okta passwordless authentication";
 }

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -18,7 +18,7 @@ var userOption = new Option<string>(
 	name: "--user",
 	description: ParameterDescriptions.User );
 
-// allow no-sandbox argument for chromium to for passwordless auth with elevated permissions
+// allow no-sandbox argument for Chromium to for passwordless auth with elevated permissions
 var bypassBrowserSecurityOption = new Option<bool>(
 	name: "--experimental-bypass-browser-security",
 	description: ParameterDescriptions.ExperimentalBypassBrowserSecurity );


### PR DESCRIPTION
### Why

We're going to brand the new feature "passwordless" rather than "auto login".
Good to use consistent language everywhere.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-522