### PR TITLE
remove `--experimental-bypass-browser-security`

### DIFF
--- a/src/D2L.Bmx/Browser.cs
+++ b/src/D2L.Bmx/Browser.cs
@@ -26,10 +26,12 @@ public static class Browser {
 		"/opt/microsoft/msedge/msedge",
 	];
 
-	public static async Task<IBrowser> LaunchBrowserAsync( string browserPath, bool noSandbox = false ) {
+	public static async Task<IBrowser> LaunchBrowserAsync( string browserPath ) {
 		var launchOptions = new LaunchOptions {
 			ExecutablePath = browserPath,
-			Args = noSandbox ? ["--no-sandbox"] : []
+			// For whatever reason, with an elevated user, Chromium cannot launch in headless mode without --no-sandbox.
+			// This isn't a big concern for BMX, because it only visits the org Okta homepage, which should be trusted.
+			Args = UserPrivileges.HasElevatedPermissions() ? ["--no-sandbox"] : []
 		};
 
 		return await Puppeteer.LaunchAsync( launchOptions );

--- a/src/D2L.Bmx/LoginHandler.cs
+++ b/src/D2L.Bmx/LoginHandler.cs
@@ -5,8 +5,7 @@ internal class LoginHandler(
 ) {
 	public async Task HandleAsync(
 		string? org,
-		string? user,
-		bool bypassBrowserSecurity
+		string? user
 	) {
 		if( !File.Exists( BmxPaths.CONFIG_FILE_NAME ) ) {
 			throw new BmxException(
@@ -17,8 +16,7 @@ internal class LoginHandler(
 			org,
 			user,
 			nonInteractive: false,
-			ignoreCache: true,
-			bypassBrowserSecurity: bypassBrowserSecurity
+			ignoreCache: true
 		);
 		Console.WriteLine( "Successfully logged in and Okta session has been cached." );
 	}

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -18,7 +18,4 @@ internal static class ParameterDescriptions {
 		Write BMX command to AWS profile, so that AWS tools & SDKs using the profile will source credentials from BMX.
 		See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.
 		""";
-
-	public const string ExperimentalBypassBrowserSecurity
-		= "Disable Chromium sandbox when using Okta passwordless authentication";
 }

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -14,15 +14,13 @@ internal class PrintHandler(
 		int? duration,
 		bool nonInteractive,
 		string? format,
-		bool cacheAwsCredentials,
-		bool bypassBrowserSecurity
+		bool cacheAwsCredentials
 	) {
 		var oktaContext = await oktaAuth.AuthenticateAsync(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
-			ignoreCache: false,
-			bypassBrowserSecurity: bypassBrowserSecurity
+			ignoreCache: false
 		);
 		var awsCreds = ( await awsCredsCreator.CreateAwsCredsAsync(
 			okta: oktaContext,

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -18,16 +18,10 @@ var userOption = new Option<string>(
 	name: "--user",
 	description: ParameterDescriptions.User );
 
-// allow no-sandbox argument for Chromium to for passwordless auth with elevated permissions
-var bypassBrowserSecurityOption = new Option<bool>(
-	name: "--experimental-bypass-browser-security",
-	description: ParameterDescriptions.ExperimentalBypassBrowserSecurity );
-
 // bmx login
-var loginCommand = new Command( "login", "Log into Okta and save an Okta session" ){
+var loginCommand = new Command( "login", "Log into Okta and save an Okta session" ) {
 	orgOption,
 	userOption,
-	bypassBrowserSecurityOption,
 };
 loginCommand.SetHandler( ( InvocationContext context ) => {
 	var consoleWriter = new ConsoleWriter();
@@ -41,8 +35,7 @@ loginCommand.SetHandler( ( InvocationContext context ) => {
 	) );
 	return handler.HandleAsync(
 		org: context.ParseResult.GetValueForOption( orgOption ),
-		user: context.ParseResult.GetValueForOption( userOption ),
-		bypassBrowserSecurity: context.ParseResult.GetValueForOption( bypassBrowserSecurityOption )
+		user: context.ParseResult.GetValueForOption( userOption )
 	);
 } );
 
@@ -126,7 +119,6 @@ var printCommand = new Command( "print", "Print AWS credentials" ) {
 	userOption,
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
-	bypassBrowserSecurityOption,
 };
 
 printCommand.SetHandler( ( InvocationContext context ) => {
@@ -155,8 +147,7 @@ printCommand.SetHandler( ( InvocationContext context ) => {
 		duration: context.ParseResult.GetValueForOption( durationOption ),
 		nonInteractive: context.ParseResult.GetValueForOption( nonInteractiveOption ),
 		format: context.ParseResult.GetValueForOption( formatOption ),
-		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption ),
-		bypassBrowserSecurity: context.ParseResult.GetValueForOption( bypassBrowserSecurityOption )
+		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption )
 	);
 } );
 
@@ -182,7 +173,6 @@ var writeCommand = new Command( "write", "Write AWS credentials to the credentia
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
 	useCredentialProcessOption,
-	bypassBrowserSecurityOption,
 };
 
 writeCommand.SetHandler( ( InvocationContext context ) => {
@@ -217,9 +207,8 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 		output: context.ParseResult.GetValueForOption( outputOption ),
 		profile: context.ParseResult.GetValueForOption( profileOption ),
 		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption ),
-		useCredentialProcess: context.ParseResult.GetValueForOption( useCredentialProcessOption ),
-		bypassBrowserSecurity: context.ParseResult.GetValueForOption( bypassBrowserSecurityOption )
-		);
+		useCredentialProcess: context.ParseResult.GetValueForOption( useCredentialProcessOption )
+	);
 } );
 
 var updateCommand = new Command( "update", "Updates BMX to the latest version" );

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -27,8 +27,7 @@ internal class WriteHandler(
 		string? output,
 		string? profile,
 		bool cacheAwsCredentials,
-		bool useCredentialProcess,
-		bool bypassBrowserSecurity
+		bool useCredentialProcess
 	) {
 		cacheAwsCredentials = cacheAwsCredentials || useCredentialProcess;
 
@@ -36,8 +35,7 @@ internal class WriteHandler(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
-			ignoreCache: false,
-			bypassBrowserSecurity: bypassBrowserSecurity
+			ignoreCache: false
 		);
 		var awsCredsInfo = await awsCredsCreator.CreateAwsCredsAsync(
 			okta: oktaContext,


### PR DESCRIPTION
### Why

BMX inherently has to trust the org Okta domain name, so we decided it doesn't make too much sense to have an additional guard on an action that only visits the org Okta homepage.
There's also considerable less user friction and code complexity once the flag is removed.

### Ticket

https://desire2learn.atlassian.net/browse/VUL-506