### PR TITLE
properly time out when waiting on the browser

### DIFF
--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -165,6 +165,7 @@ internal class OktaAuthenticator(
 
 		using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( 15 ) );
 		var sessionIdTcs = new TaskCompletionSource<string?>( TaskCreationOptions.RunContinuationsAsynchronously );
+		cancellationTokenSource.Token.Register( () => sessionIdTcs.TrySetCanceled() );
 		string? sessionId = null;
 
 		try {


### PR DESCRIPTION
If Okta redirects us to an unexpected page, we'd be stuck there waiting forever, because the current timeout logic is flawed.