### PR TITLE
turn `Browser` non-static

### DIFF
--- a/src/D2L.Bmx/BrowserLauncher.cs
+++ b/src/D2L.Bmx/BrowserLauncher.cs
@@ -3,7 +3,12 @@ using PuppeteerSharp;
 
 namespace D2L.Bmx;
 
-public static class Browser {
+internal interface IBrowserLauncher {
+	Task<IBrowser> LaunchAsync( string browserPath );
+	bool TryGetPathToBrowser( [NotNullWhen( returnValue: true )] out string? path );
+}
+
+internal class BrowserLauncher : IBrowserLauncher {
 
 	// https://github.com/microsoft/playwright/blob/6763d5ab6bd20f1f0fc879537855a26c7644a496/packages/playwright-core/src/server/registry/index.ts#L630
 	private static readonly string[] WindowsEnvironmentVariables = [
@@ -26,7 +31,7 @@ public static class Browser {
 		"/opt/microsoft/msedge/msedge",
 	];
 
-	public static async Task<IBrowser> LaunchBrowserAsync( string browserPath ) {
+	async Task<IBrowser> IBrowserLauncher.LaunchAsync( string browserPath ) {
 		var launchOptions = new LaunchOptions {
 			ExecutablePath = browserPath,
 			// For whatever reason, with an elevated user, Chromium cannot launch in headless mode without --no-sandbox.
@@ -37,7 +42,7 @@ public static class Browser {
 		return await Puppeteer.LaunchAsync( launchOptions );
 	}
 
-	public static bool TryGetPathToBrowser( [NotNullWhen( returnValue: true )] out string? path ) {
+	bool IBrowserLauncher.TryGetPathToBrowser( [NotNullWhen( returnValue: true )] out string? path ) {
 		path = null;
 		if( OperatingSystem.IsWindows() ) {
 			foreach( string windowsPartialPath in WindowsPartialPaths ) {

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -14,6 +14,7 @@ internal record OktaAuthenticatedContext(
 internal class OktaAuthenticator(
 	IOktaClientFactory oktaClientFactory,
 	IOktaSessionStorage sessionStorage,
+	IBrowserLauncher browserLauncher,
 	IConsolePrompter consolePrompter,
 	IConsoleWriter consoleWriter,
 	BmxConfig config
@@ -58,7 +59,7 @@ internal class OktaAuthenticator(
 			return new( Org: org, User: user, Client: oktaAuthenticated );
 		}
 
-		if( Browser.TryGetPathToBrowser( out string? browserPath ) ) {
+		if( browserLauncher.TryGetPathToBrowser( out string? browserPath ) ) {
 			if( !nonInteractive ) {
 				Console.Error.WriteLine( "Attempting Okta passwordless authentication..." );
 			}
@@ -113,7 +114,7 @@ internal class OktaAuthenticator(
 		string user,
 		string browserPath
 	) {
-		await using var browser = await Browser.LaunchBrowserAsync( browserPath );
+		await using var browser = await browserLauncher.LaunchAsync( browserPath );
 
 		using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( 15 ) );
 		var sessionIdTcs = new TaskCompletionSource<string?>( TaskCreationOptions.RunContinuationsAsynchronously );

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -29,6 +29,7 @@ loginCommand.SetHandler( ( InvocationContext context ) => {
 	var handler = new LoginHandler( new OktaAuthenticator(
 		new OktaClientFactory(),
 		new OktaSessionStorage(),
+		new BrowserLauncher(),
 		new ConsolePrompter(),
 		consoleWriter,
 		config
@@ -129,6 +130,7 @@ printCommand.SetHandler( ( InvocationContext context ) => {
 		new OktaAuthenticator(
 			new OktaClientFactory(),
 			new OktaSessionStorage(),
+			new BrowserLauncher(),
 			consolePrompter,
 			consoleWriter,
 			config ),
@@ -183,6 +185,7 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 		new OktaAuthenticator(
 			new OktaClientFactory(),
 			new OktaSessionStorage(),
+			new BrowserLauncher(),
 			consolePrompter,
 			consoleWriter,
 			config ),


### PR DESCRIPTION
nit: such side-effect heavy and environment dependent operations should ideally not be static