### PR TITLE
don't try passwordless on Linux

### DIFF
--- a/src/D2L.Bmx/BrowserLauncher.cs
+++ b/src/D2L.Bmx/BrowserLauncher.cs
@@ -26,10 +26,6 @@ internal class BrowserLauncher : IBrowserLauncher {
 		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 	];
-	private static readonly string[] LinuxPaths = [
-		"/opt/google/chrome/chrome",
-		"/opt/microsoft/msedge/msedge",
-	];
 
 	async Task<IBrowser> IBrowserLauncher.LaunchAsync( string browserPath ) {
 		var launchOptions = new LaunchOptions {
@@ -59,10 +55,9 @@ internal class BrowserLauncher : IBrowserLauncher {
 		} else if( OperatingSystem.IsMacOS() ) {
 			path = Array.Find( MacPaths, File.Exists );
 			return path is not null;
-		} else if( OperatingSystem.IsLinux() ) {
-			path = Array.Find( LinuxPaths, File.Exists );
-			return path is not null;
 		}
+		// Okta DSSO is only supported for Windows and Mac. There's no point for us to support Linux.
+		// Chromium is finicky on Linux anyway.
 		return false;
 	}
 }

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -59,7 +59,7 @@ internal class OktaAuthenticator(
 			return new( Org: org, User: user, Client: oktaAuthenticated );
 		}
 
-		if( browserLauncher.TryGetPathToBrowser( out string? browserPath ) ) {
+		if( !OperatingSystem.IsLinux() && browserLauncher.TryGetPathToBrowser( out string? browserPath ) ) {
 			if( !nonInteractive ) {
 				Console.Error.WriteLine( "Attempting Okta passwordless authentication..." );
 			}

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -59,7 +59,12 @@ internal class OktaAuthenticator(
 			return new( Org: org, User: user, Client: oktaAuthenticated );
 		}
 
-		if( !OperatingSystem.IsLinux() && browserLauncher.TryGetPathToBrowser( out string? browserPath ) ) {
+		if(
+			// `TryGetPathToBrowser` does return `false` for Linux, but excluding Linux earlier here helps
+			// the compiler trim more unused code (e.g. all of PuppeteerSharp)
+			!OperatingSystem.IsLinux()
+			&& browserLauncher.TryGetPathToBrowser( out string? browserPath )
+		) {
 			if( !nonInteractive ) {
 				Console.Error.WriteLine( "Attempting Okta passwordless authentication..." );
 			}


### PR DESCRIPTION
Okta doesn't support DSSO on Linux anyway, and in my testing BMX always runs into the "unknown browser error" territory when I run it on Linux with Chrome installed.
Might as well remove the bloat and noise.