### PR TITLE
Use spectre.console lib to manage ANSI escape code

### DIFF
--- a/src/D2L.Bmx/ConsoleWriter.cs
+++ b/src/D2L.Bmx/ConsoleWriter.cs
@@ -1,3 +1,5 @@
+using Spectre.Console;
+
 namespace D2L.Bmx;
 
 internal interface IConsoleWriter {
@@ -11,7 +13,6 @@ internal interface IConsoleWriter {
 // if stdout is redirected (e.g. typical use case for `bmx print`), we won't get any coloured text on stderr.
 // See https://github.com/dotnet/runtime/issues/83146.
 // Furthermore, ANSI escape codes give us greater control over the spread of custom background colour.
-// TODO: use a library to manage ANSI codes and NO_COLOR?
 internal class ConsoleWriter : IConsoleWriter {
 	// .NET runtime subscribes to the informal standard from https://no-color.org/. We should too.
 	// https://github.com/dotnet/runtime/blob/v9.0.0-preview.6.24327.7/src/libraries/Common/src/System/Console/ConsoleUtils.cs#L32-L34
@@ -19,48 +20,31 @@ internal class ConsoleWriter : IConsoleWriter {
 		= Environment.GetEnvironmentVariable( "NO_COLOR" ) == "1" || !VirtualTerminal.TryEnableOnStderr();
 
 	void IConsoleWriter.WriteParameter( string description, string value, ParameterSource source ) {
-		if( _noColor ) {
-			Console.Error.WriteLine( $"{description}: {value} (from {source})" );
-			return;
-		}
-		// description: default
-		// value: bright cyan
-		// source: grey / bright black
-		Console.Error.WriteLine( $"\x1b[0m{description}: \x1b[96m{value} \x1b[90m(from {source})\x1b[0m" );
+		string valueColor = _noColor ? "default" : "cyan2";
+		string sourceColor = _noColor ? "default" : "grey";
+		AnsiConsole.MarkupLine( $"[default]{description}:[/] [{valueColor}]{value}[/] [{sourceColor}](from {source})[/]" );
 	}
 
 	void IConsoleWriter.WriteUpdateMessage( string text ) {
-		if( _noColor ) {
-			Console.Error.WriteLine( text );
-			Console.Error.WriteLine();
-			return;
-		}
 		// Trim entries so we don't have extra `\r` characters on Windows.
 		// Splitting on `Environment.NewLine` isn't as safe, because we might also use `\n` on Windows.
 		string[] lines = text.Split( '\n', StringSplitOptions.TrimEntries );
 		int maxLineLength = lines.Max( l => l.Length );
+		string color = _noColor ? "default" : "black on white";
 		foreach( string line in lines ) {
 			string paddedLine = line.PadRight( maxLineLength );
-			Console.Error.WriteLine( $"\x1b[0m\x1b[30;47m{paddedLine}\x1b[0m" );
+			AnsiConsole.MarkupLine( $"[{color}]{paddedLine}[/]" );
 		}
 		Console.Error.WriteLine();
 	}
 
 	void IConsoleWriter.WriteWarning( string text ) {
-		if( _noColor ) {
-			Console.Error.WriteLine( text );
-			return;
-		}
-		// bright yellow - 93
-		Console.Error.WriteLine( $"\x1b[0m\x1b[93m{text}\x1b[0m" );
+		string color = _noColor ? "default" : "yellow";
+		AnsiConsole.MarkupLine( $"[{color}]{text}[/]" );
 	}
 
 	void IConsoleWriter.WriteError( string text ) {
-		if( _noColor ) {
-			Console.Error.WriteLine( text );
-			return;
-		}
-		// bright red - 91
-		Console.Error.WriteLine( $"\x1b[0m\x1b[91m{text}\x1b[0m" );
+		string color = _noColor ? "default" : "red";
+		AnsiConsole.MarkupLine( $"[{color}]{text}[/]" );
 	}
 }

--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.68" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="PuppeteerSharp" Version="20.0.3" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Why
Avoid using hardcoded ANSI escape codes to make it more readable.

![test](https://github.com/user-attachments/assets/bcee06d4-906b-43dc-a75b-303c78ac8f06)


### Ticket

VUL-424
