### PR TITLE
Add AWS_PROFILE env var to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ aws sts get-caller-identity --profile <aws_profile>
 Or use the `AWS_PROFILE` environment variable to set the default profile for multiple commands:
 
 ```Powershell
-$env:AWS_PROFILE='<aws_profile>' 
+$env:AWS_PROFILE='<aws_profile>'
 ```
 
 ### Provide dynamic AWS credentials to a profile

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ eval "$(bmx print --account <aws_account_name> --role <aws_role_name>)"
 
 ### Static AWS credentials in a profile
 
-To set up AWS credentials in a profile, run
+AWS named profiles allow credentials to be stored and referenced easily. To set up AWS credentials in a profile, run
 
 ```Powershell
 bmx write --account <aws_account_name> --role <aws_role_name> --profile <aws_profile>
@@ -51,6 +51,12 @@ You can use your profile by configuring any supporting AWS client. For example, 
 
 ```Powershell
 aws sts get-caller-identity --profile <aws_profile>
+```
+
+Or use the `AWS_PROFILE` environment variable to set the default profile for multiple commands:
+
+```Powershell
+$env:AWS_PROFILE='<aws_profile>' 
 ```
 
 ### Provide dynamic AWS credentials to a profile


### PR DESCRIPTION
### Why
The info in my change is obvious to some folks, but I lost a good chunk of time to this and it seems like a straightforward addition.

Essentially when I read the readme I only saw a way to use profiles when invoking AWS through the CLI (`--profile` option), whereas my usage was inside Node scripts. I just wanted env var(s) I could set so that my Node scripts would work. I ended up trying to go the `bmx print` route but had lots of grief trying to do that.

I also thought the profile was a BMX concept and not AWS, which is my fault but hopefully this makes it clearer!

### Ticket
VOY-1
