### PR TITLE
update puppeteersharp

### DIFF
--- a/src/D2L.Bmx/D2L.Bmx.csproj
+++ b/src/D2L.Bmx/D2L.Bmx.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.37" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.68" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="PuppeteerSharp" Version="20.0.3" />
+    <PackageReference Include="PuppeteerSharp" Version="20.2.2" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>


### PR DESCRIPTION
### Why

We are seeing passwordless auth failing and likely is related to this change here https://github.com/hardkoded/puppeteer-sharp/pull/2924 . Bumping the version that includes this change should be enough

### Ticket

VUL-3643
