### PR TITLE
check for ACTIVE session id when doing passwordless authentication

### DIFF
--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -185,14 +185,14 @@ internal class ConsolePrompter : IConsolePrompter {
 				Console.Error.Write( moveLeftString + emptyString + moveLeftString );
 				passwordBuilder.Clear();
 			} else
-			// The backspace key is received as the DEL character in raw mode
-			if( ( key == '\b' || key == DEL ) && passwordBuilder.Length > 0 ) {
-				Console.Error.Write( "\b \b" );
-				passwordBuilder.Length--;
-			} else if( !char.IsControl( key ) ) {
-				Console.Error.Write( '*' );
-				passwordBuilder.Append( key );
-			}
+				// The backspace key is received as the DEL character in raw mode
+				if( ( key == '\b' || key == DEL ) && passwordBuilder.Length > 0 ) {
+					Console.Error.Write( "\b \b" );
+					passwordBuilder.Length--;
+				} else if( !char.IsControl( key ) ) {
+					Console.Error.Write( '*' );
+					passwordBuilder.Append( key );
+				}
 		}
 	}
 }

--- a/src/D2L.Bmx/Okta/Models/OktaSession.cs
+++ b/src/D2L.Bmx/Okta/Models/OktaSession.cs
@@ -4,6 +4,7 @@ internal record OktaSession(
 	string Id,
 	string Login,
 	string UserId,
+	string Status,
 	DateTimeOffset CreatedAt,
 	DateTimeOffset ExpiresAt
 );

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -138,10 +138,9 @@ internal class OktaAuthenticator(
 		var oktaAuthenticatedClient = oktaClientFactory.CreateAuthenticatedClient( orgUrl, sessionId );
 		var oktaSession = await oktaAuthenticatedClient.GetCurrentOktaSessionAsync();
 		if( oktaSession.Status != "ACTIVE" ) {
-			messageWriter.WriteWarning( """
-				Okta passwordless authentication failed.
-				Okta did not provide an expected response.
-				""" );
+			if( BmxEnvironment.IsDebug ) {
+				messageWriter.WriteWarning( "Okta passwordless authentication failed" );
+			}
 			return null;
 		}
 

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -137,6 +137,14 @@ internal class OktaAuthenticator(
 
 		var oktaAuthenticatedClient = oktaClientFactory.CreateAuthenticatedClient( orgUrl, sessionId );
 		var oktaSession = await oktaAuthenticatedClient.GetCurrentOktaSessionAsync();
+		if( oktaSession.Status != "ACTIVE" ) {
+			messageWriter.WriteWarning( """
+				Okta passwordless authentication failed.
+				An active session ID was not returned from Okta.
+				""" );
+			return null;
+		}
+
 		string sessionLogin = oktaSession.Login.Split( "@" )[0];
 		string providedLogin = user.Split( "@" )[0];
 		if( !sessionLogin.Equals( providedLogin, StringComparison.OrdinalIgnoreCase ) ) {

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -140,7 +140,7 @@ internal class OktaAuthenticator(
 		if( oktaSession.Status != "ACTIVE" ) {
 			messageWriter.WriteWarning( """
 				Okta passwordless authentication failed.
-				An active session ID was not returned from Okta.
+				Okta did not provide an expected response.
 				""" );
 			return null;
 		}


### PR DESCRIPTION
### Why

Turning off zscaler gives a bit of time where DSSO will return a session id but not one with status `ACTIVE` and so it is useless 


```
C:\code\bmx\src\D2L.Bmx\bin\Release\net9.0\win-x64\publish [main ≡ +1 ~2 -0 !]> bmx login
Okta org or domain name: d2l (from config file)
Okta username: lgordon (from config file)
Attempting Okta passwordless authentication...
Launching browser: C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
Creating new browser tab
Navigating to https://d2l.okta.com/
Browser loaded https://d2l.okta.com/
Browser loaded
https://d2l.kerberos.okta.com/login/agentlessDsso/interact?precheck=false&interactionHandle=008f3771y2gka-vRMCmgq3qHDLsB
FHfxLabbDc1wXJ
Browser loaded
https://d2l.okta.com/login/second-factor?fromURI=%2Fapp%2FUserHome%3Fiss%3Dhttps%253A%252F%252Fd2l.okta.com%26login_hint
%3Dlgordon%2540desire2learn.com
Okta passwordless authentication failed.
An active session ID was not returned from Okta.
Falling back to Okta password authentication...
Okta password:
```

### Ticket

[HOD-4575 - BMX > fix passwordless auth](https://desire2learn.atlassian.net/browse/HOD-4575)
