### PR TITLE
add passwordless timeout config value

### DIFF
--- a/src/D2L.Bmx/BmxConfig.cs
+++ b/src/D2L.Bmx/BmxConfig.cs
@@ -1,11 +1,5 @@
 namespace D2L.Bmx;
 
-internal static class PasswordlessTimeoutDefaults {
-	public const int Min = 5;
-	public const int Max = 30;
-	public const int Default = 60;
-}
-
 internal record BmxConfig(
 	string? Org,
 	string? User,

--- a/src/D2L.Bmx/BmxConfig.cs
+++ b/src/D2L.Bmx/BmxConfig.cs
@@ -3,7 +3,7 @@ namespace D2L.Bmx;
 internal static class PasswordlessTimeoutDefaults {
 	public const int Min = 5;
 	public const int Max = 30;
-	public const int Default = 30;
+	public const int Default = 60;
 }
 
 internal record BmxConfig(

--- a/src/D2L.Bmx/BmxConfig.cs
+++ b/src/D2L.Bmx/BmxConfig.cs
@@ -1,10 +1,17 @@
 namespace D2L.Bmx;
 
+internal static class PasswordlessTimeoutDefaults {
+	public const int Min = 5;
+	public const int Max = 30;
+	public const int Default = 30;
+}
+
 internal record BmxConfig(
 	string? Org,
 	string? User,
 	string? Account,
 	string? Role,
 	string? Profile,
-	int? Duration
+	int? Duration,
+	int? PasswordlessTimeout
 );

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -47,13 +47,10 @@ internal class BmxConfigProvider(
 		int? passwordlessTimeout = null;
 		if( !string.IsNullOrEmpty( data.Global["passwordlessTimeout"] ) ) {
 			if( !int.TryParse( data.Global["passwordlessTimeout"], out int configTimeout )
-				|| configTimeout < 0
-				|| ( configTimeout > 0 && configTimeout < PasswordlessTimeoutDefaults.Min )
-				|| configTimeout > PasswordlessTimeoutDefaults.Max ) {
+				|| configTimeout < 0 ) {
 				throw new BmxException(
 					"Invalid passwordlessTimeout in config."
-					+ $" Must be 0 (disabled) or between {PasswordlessTimeoutDefaults.Min}"
-					+ $" and {PasswordlessTimeoutDefaults.Max} seconds." );
+					+ " Must be 0 (to disable passwordless authentication) or a positive number of seconds." );
 			}
 			passwordlessTimeout = configTimeout;
 		}

--- a/src/D2L.Bmx/BmxConfigProvider.cs
+++ b/src/D2L.Bmx/BmxConfigProvider.cs
@@ -44,13 +44,28 @@ internal class BmxConfigProvider(
 			duration = configDuration;
 		}
 
+		int? passwordlessTimeout = null;
+		if( !string.IsNullOrEmpty( data.Global["passwordlessTimeout"] ) ) {
+			if( !int.TryParse( data.Global["passwordlessTimeout"], out int configTimeout )
+				|| configTimeout < 0
+				|| ( configTimeout > 0 && configTimeout < PasswordlessTimeoutDefaults.Min )
+				|| configTimeout > PasswordlessTimeoutDefaults.Max ) {
+				throw new BmxException(
+					"Invalid passwordlessTimeout in config."
+					+ $" Must be 0 (disabled) or between {PasswordlessTimeoutDefaults.Min}"
+					+ $" and {PasswordlessTimeoutDefaults.Max} seconds." );
+			}
+			passwordlessTimeout = configTimeout;
+		}
+
 		return new BmxConfig(
 			Org: data.Global["org"],
 			User: data.Global["user"],
 			Account: data.Global["account"],
 			Role: data.Global["role"],
 			Profile: data.Global["profile"],
-			Duration: duration
+			Duration: duration,
+			PasswordlessTimeout: passwordlessTimeout
 		);
 	}
 
@@ -74,6 +89,9 @@ internal class BmxConfigProvider(
 		}
 		if( config.Duration.HasValue ) {
 			data.Global["duration"] = $"{config.Duration}";
+		}
+		if( config.PasswordlessTimeout.HasValue ) {
+			data.Global["passwordlessTimeout"] = $"{config.PasswordlessTimeout}";
 		}
 
 		fs.Position = 0;

--- a/src/D2L.Bmx/ConfigureHandler.cs
+++ b/src/D2L.Bmx/ConfigureHandler.cs
@@ -9,6 +9,7 @@ internal class ConfigureHandler(
 		string? org,
 		string? user,
 		int? duration,
+		int? passwordlessTimeout,
 		bool nonInteractive
 	) {
 
@@ -24,13 +25,18 @@ internal class ConfigureHandler(
 			duration = consolePrompter.PromptDuration();
 		}
 
+		if( passwordlessTimeout is null && !nonInteractive ) {
+			passwordlessTimeout = consolePrompter.PromptPasswordlessTimeout();
+		}
+
 		BmxConfig config = new(
 			Org: org,
 			User: user,
 			Account: null,
 			Role: null,
 			Profile: null,
-			Duration: duration
+			Duration: duration,
+			PasswordlessTimeout: passwordlessTimeout
 		);
 		configProvider.SaveConfiguration( config );
 		Console.WriteLine( "Your configuration has been created. Okta sessions will now also be cached." );

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -9,6 +9,7 @@ internal interface IConsolePrompter {
 	string PromptUser( bool allowEmptyInput );
 	string PromptPassword();
 	int? PromptDuration();
+	int? PromptPasswordlessTimeout();
 	string PromptAccount( string[] accounts );
 	string PromptRole( string[] roles );
 	OktaMfaFactor SelectMfa( OktaMfaFactor[] mfaOptions );
@@ -61,6 +62,25 @@ internal class ConsolePrompter : IConsolePrompter {
 			return null;
 		}
 		return duration;
+	}
+
+	int? IConsolePrompter.PromptPasswordlessTimeout() {
+		Console.Error.Write(
+			"Okta passwordless (DSSO) timeout in seconds"
+			+ " (optional, 0 to disable,"
+			+ $" {PasswordlessTimeoutDefaults.Min}-{PasswordlessTimeoutDefaults.Max},"
+			+ $" default: {PasswordlessTimeoutDefaults.Default}): " );
+		string? input = Console.ReadLine();
+		if( input is null || string.IsNullOrWhiteSpace( input ) ) {
+			return null;
+		}
+		if( int.TryParse( input, out int timeout )
+			&& ( timeout == 0
+				|| ( timeout >= PasswordlessTimeoutDefaults.Min
+					&& timeout <= PasswordlessTimeoutDefaults.Max ) ) ) {
+			return timeout;
+		}
+		return null;
 	}
 
 	string IConsolePrompter.PromptAccount( string[] accounts ) {
@@ -185,14 +205,14 @@ internal class ConsolePrompter : IConsolePrompter {
 				Console.Error.Write( moveLeftString + emptyString + moveLeftString );
 				passwordBuilder.Clear();
 			} else
-			// The backspace key is received as the DEL character in raw mode
-			if( ( key == '\b' || key == DEL ) && passwordBuilder.Length > 0 ) {
-				Console.Error.Write( "\b \b" );
-				passwordBuilder.Length--;
-			} else if( !char.IsControl( key ) ) {
-				Console.Error.Write( '*' );
-				passwordBuilder.Append( key );
-			}
+				// The backspace key is received as the DEL character in raw mode
+				if( ( key == '\b' || key == DEL ) && passwordBuilder.Length > 0 ) {
+					Console.Error.Write( "\b \b" );
+					passwordBuilder.Length--;
+				} else if( !char.IsControl( key ) ) {
+					Console.Error.Write( '*' );
+					passwordBuilder.Append( key );
+				}
 		}
 	}
 }

--- a/src/D2L.Bmx/ConsolePrompter.cs
+++ b/src/D2L.Bmx/ConsolePrompter.cs
@@ -65,19 +65,13 @@ internal class ConsolePrompter : IConsolePrompter {
 	}
 
 	int? IConsolePrompter.PromptPasswordlessTimeout() {
-		Console.Error.Write(
-			"Okta passwordless (DSSO) timeout in seconds"
-			+ " (optional, 0 to disable,"
-			+ $" {PasswordlessTimeoutDefaults.Min}-{PasswordlessTimeoutDefaults.Max},"
-			+ $" default: {PasswordlessTimeoutDefaults.Default}): " );
+		Console.Error.Write( $"{ParameterDescriptions.PasswordlessTimeout} " +
+				"(optional, 0 to disable passwordless authentication, default: 30): " );
 		string? input = Console.ReadLine();
 		if( input is null || string.IsNullOrWhiteSpace( input ) ) {
 			return null;
 		}
-		if( int.TryParse( input, out int timeout )
-			&& ( timeout == 0
-				|| ( timeout >= PasswordlessTimeoutDefaults.Min
-					&& timeout <= PasswordlessTimeoutDefaults.Max ) ) ) {
+		if( int.TryParse( input, out int timeout ) && timeout >= 0 ) {
 			return timeout;
 		}
 		return null;

--- a/src/D2L.Bmx/LoginHandler.cs
+++ b/src/D2L.Bmx/LoginHandler.cs
@@ -5,7 +5,8 @@ internal class LoginHandler(
 ) {
 	public async Task HandleAsync(
 		string? org,
-		string? user
+		string? user,
+		int? passwordlessTimeout
 	) {
 		if( !File.Exists( BmxPaths.CONFIG_FILE_NAME ) ) {
 			throw new BmxException(
@@ -16,7 +17,8 @@ internal class LoginHandler(
 			org,
 			user,
 			nonInteractive: false,
-			ignoreCache: true
+			ignoreCache: true,
+			passwordlessTimeout: passwordlessTimeout
 		);
 		Console.WriteLine( "Successfully logged in and Okta session has been cached." );
 	}

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -23,7 +23,8 @@ internal class OktaAuthenticator(
 		string? org,
 		string? user,
 		bool nonInteractive,
-		bool ignoreCache
+		bool ignoreCache,
+		int? passwordlessTimeout
 	) {
 		var orgSource = ParameterSource.CliArg;
 		if( string.IsNullOrEmpty( org ) && !string.IsNullOrEmpty( config.Org ) ) {
@@ -65,19 +66,30 @@ internal class OktaAuthenticator(
 			OperatingSystem.IsWindows()
 			&& browserLauncher.TryGetPathToBrowser( out string? browserPath )
 		) {
-			if( !nonInteractive ) {
-				Console.Error.WriteLine( "Attempting Okta passwordless authentication..." );
-			}
-			oktaAuthenticated = await GetDssoAuthenticatedClientAsync(
-				orgUrl,
-				user,
-				browserPath
-			);
-			if( oktaAuthenticated is not null ) {
-				return new( Org: org, User: user, Client: oktaAuthenticated );
-			}
-			if( !nonInteractive ) {
-				Console.Error.WriteLine( "Falling back to Okta password authentication..." );
+			int resolvedTimeout = passwordlessTimeout
+				?? config.PasswordlessTimeout
+				?? PasswordlessTimeoutDefaults.Default;
+
+			if( resolvedTimeout == 0 ) {
+				if( BmxEnvironment.IsDebug ) {
+					messageWriter.WriteWarning( "Okta passwordless authentication disabled via configuration" );
+				}
+			} else {
+				if( !nonInteractive ) {
+					Console.Error.WriteLine( "Attempting Okta passwordless authentication..." );
+				}
+				oktaAuthenticated = await GetDssoAuthenticatedClientAsync(
+					orgUrl,
+					user,
+					browserPath,
+					resolvedTimeout
+				);
+				if( oktaAuthenticated is not null ) {
+					return new( Org: org, User: user, Client: oktaAuthenticated );
+				}
+				if( !nonInteractive ) {
+					Console.Error.WriteLine( "Falling back to Okta password authentication..." );
+				}
 			}
 		} else if( BmxEnvironment.IsDebug ) {
 			messageWriter.WriteWarning( "No suitable browser found for Okta passwordless authentication" );
@@ -115,12 +127,13 @@ internal class OktaAuthenticator(
 	private async Task<IOktaAuthenticatedClient?> GetDssoAuthenticatedClientAsync(
 		Uri orgUrl,
 		string user,
-		string browserPath
+		string browserPath,
+		int timeoutSeconds
 	) {
 		string? sessionId = null;
 
 		try {
-			sessionId = await GetSessionIdFromBrowserAsync( browserPath, orgUrl );
+			sessionId = await GetSessionIdFromBrowserAsync( browserPath, orgUrl, timeoutSeconds );
 		} catch( TaskCanceledException ex ) {
 			if( BmxEnvironment.IsDebug ) {
 				messageWriter.WriteWarning( $"Okta passwordless authentication timed out. \n{ex}" );
@@ -151,7 +164,7 @@ internal class OktaAuthenticator(
 		return oktaAuthenticatedClient;
 	}
 
-	private async Task<string?> GetSessionIdFromBrowserAsync( string browserPath, Uri orgUrl ) {
+	private async Task<string?> GetSessionIdFromBrowserAsync( string browserPath, Uri orgUrl, int timeoutSeconds ) {
 		if( BmxEnvironment.IsDebug ) {
 			messageWriter.WriteWarning( $"Launching browser: {browserPath}" );
 		}
@@ -159,12 +172,13 @@ internal class OktaAuthenticator(
 
 		var sessionIdTcs = new TaskCompletionSource<string?>( TaskCreationOptions.RunContinuationsAsynchronously );
 
-		// cancel if the total time exceeds 15 seconds, including all page loads and retries
-		using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( 15 ) );
+		// cancel if the total time exceeds the configured timeout, including all page loads and retries
+		using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( timeoutSeconds ) );
 		cancellationTokenSource.Token.Register( () => sessionIdTcs.TrySetCanceled() );
 
-		// cancel if we can't load the first page for 6 seconds
-		using var pageTimer = new System.Timers.Timer( TimeSpan.FromSeconds( 6 ) ) { AutoReset = false };
+		// cancel if we can't load the first page within a derived timeout
+		using var pageTimer = new System.Timers.Timer(
+			TimeSpan.FromSeconds( Math.Min( 6, timeoutSeconds / 2 ) ) ) { AutoReset = false };
 		pageTimer.Elapsed += ( _, _ ) => cancellationTokenSource.Cancel();
 		pageTimer.Start();
 

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -205,8 +205,10 @@ internal class OktaAuthenticator(
 
 		async Task OnPageLoadAsync() {
 			// reset the per-page timer on every page load
-			pageTimer.Stop();
-			pageTimer.Start();
+			lock( pageTimer ) {
+				pageTimer.Stop();
+				pageTimer.Start();
+			}
 
 			if( BmxEnvironment.IsDebug ) {
 				messageWriter.WriteWarning( $"Browser loaded {page.Url}" );

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -185,7 +185,7 @@ internal class OktaAuthenticator(
 
 		// cancel if we can't load the first page within a derived timeout
 		using var pageTimer = new System.Timers.Timer(
-			TimeSpan.FromSeconds( Math.Max( 6, timeoutSeconds / 2 ) ) ) { AutoReset = false };
+			TimeSpan.FromSeconds( Math.Max( 6, timeoutSeconds / 2.0 ) ) ) { AutoReset = false };
 		pageTimer.Elapsed += ( _, _ ) => cancellationTokenSource.Cancel();
 		pageTimer.Start();
 
@@ -208,7 +208,7 @@ internal class OktaAuthenticator(
 			lock( pageTimer ) {
 				pageTimer.Stop();
 				// we give the first page 6 sec to load, but 3 sec is probably enough for subsequent pages
-				pageTimer.Interval = Math.Max( 3, timeoutSeconds / 4 ) * 1000;
+				pageTimer.Interval = Math.Max( 3, timeoutSeconds / 2.0 ) * 1000;
 				pageTimer.Start();
 			}
 

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -68,7 +68,7 @@ internal class OktaAuthenticator(
 		) {
 			int resolvedTimeout = passwordlessTimeout
 				?? config.PasswordlessTimeout
-				?? PasswordlessTimeoutDefaults.Default;
+				?? 30;
 
 			if( resolvedTimeout == 0 ) {
 				if( BmxEnvironment.IsDebug ) {

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -183,9 +183,9 @@ internal class OktaAuthenticator(
 		using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( timeoutSeconds ) );
 		cancellationTokenSource.Token.Register( () => sessionIdTcs.TrySetCanceled() );
 
-		// cancel if we can't load the first page within a derived timeout
+		// cancel if we can't load a page within half the total timeout
 		using var pageTimer = new System.Timers.Timer(
-			TimeSpan.FromSeconds( Math.Max( 6, timeoutSeconds / 2.0 ) ) ) { AutoReset = false };
+			TimeSpan.FromSeconds( timeoutSeconds / 2.0 ) ) { AutoReset = false };
 		pageTimer.Elapsed += ( _, _ ) => cancellationTokenSource.Cancel();
 		pageTimer.Start();
 
@@ -205,12 +205,8 @@ internal class OktaAuthenticator(
 
 		async Task OnPageLoadAsync() {
 			// reset the per-page timer on every page load
-			lock( pageTimer ) {
-				pageTimer.Stop();
-				// we give the first page 6 sec to load, but 3 sec is probably enough for subsequent pages
-				pageTimer.Interval = Math.Max( 3, timeoutSeconds / 2.0 ) * 1000;
-				pageTimer.Start();
-			}
+			pageTimer.Stop();
+			pageTimer.Start();
 
 			if( BmxEnvironment.IsDebug ) {
 				messageWriter.WriteWarning( $"Browser loaded {page.Url}" );

--- a/src/D2L.Bmx/OktaAuthenticator.cs
+++ b/src/D2L.Bmx/OktaAuthenticator.cs
@@ -185,7 +185,7 @@ internal class OktaAuthenticator(
 
 		// cancel if we can't load the first page within a derived timeout
 		using var pageTimer = new System.Timers.Timer(
-			TimeSpan.FromSeconds( Math.Min( 6, timeoutSeconds / 2 ) ) ) { AutoReset = false };
+			TimeSpan.FromSeconds( Math.Max( 6, timeoutSeconds / 2 ) ) ) { AutoReset = false };
 		pageTimer.Elapsed += ( _, _ ) => cancellationTokenSource.Cancel();
 		pageTimer.Start();
 
@@ -208,7 +208,7 @@ internal class OktaAuthenticator(
 			lock( pageTimer ) {
 				pageTimer.Stop();
 				// we give the first page 6 sec to load, but 3 sec is probably enough for subsequent pages
-				pageTimer.Interval = 3000;
+				pageTimer.Interval = Math.Max( 3, timeoutSeconds / 4 ) * 1000;
 				pageTimer.Start();
 			}
 

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -14,10 +14,8 @@ internal static class ParameterDescriptions {
 	public const string NonInteractive = "Run non-interactively without showing any prompts";
 	public const string CacheAwsCredentials =
 		"Enables Cache for AWS tokens. Implied if '--use-credential-process' is supplied";
-	public static readonly string PasswordlessTimeout =
-		"Timeout for Okta passwordless (DSSO) authentication in seconds"
-		+ $" (0 to disable, {PasswordlessTimeoutDefaults.Min}-{PasswordlessTimeoutDefaults.Max},"
-		+ $" default: {PasswordlessTimeoutDefaults.Default})";
+	public const string PasswordlessTimeout =
+		"Timeout for Okta passwordless authentication in seconds";
 	public const string UseCredentialProcess = """
 		Write BMX command to AWS profile, so that AWS tools & SDKs using the profile will source credentials from BMX.
 		See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.

--- a/src/D2L.Bmx/ParameterDescriptions.cs
+++ b/src/D2L.Bmx/ParameterDescriptions.cs
@@ -14,6 +14,10 @@ internal static class ParameterDescriptions {
 	public const string NonInteractive = "Run non-interactively without showing any prompts";
 	public const string CacheAwsCredentials =
 		"Enables Cache for AWS tokens. Implied if '--use-credential-process' is supplied";
+	public static readonly string PasswordlessTimeout =
+		"Timeout for Okta passwordless (DSSO) authentication in seconds"
+		+ $" (0 to disable, {PasswordlessTimeoutDefaults.Min}-{PasswordlessTimeoutDefaults.Max},"
+		+ $" default: {PasswordlessTimeoutDefaults.Default})";
 	public const string UseCredentialProcess = """
 		Write BMX command to AWS profile, so that AWS tools & SDKs using the profile will source credentials from BMX.
 		See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.

--- a/src/D2L.Bmx/PrintHandler.cs
+++ b/src/D2L.Bmx/PrintHandler.cs
@@ -14,13 +14,15 @@ internal class PrintHandler(
 		int? duration,
 		bool nonInteractive,
 		string? format,
-		bool cacheAwsCredentials
+		bool cacheAwsCredentials,
+		int? passwordlessTimeout
 	) {
 		var oktaContext = await oktaAuth.AuthenticateAsync(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
-			ignoreCache: false
+			ignoreCache: false,
+			passwordlessTimeout: passwordlessTimeout
 		);
 		var awsCreds = ( await awsCredsCreator.CreateAwsCredsAsync(
 			okta: oktaContext,

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -24,20 +24,10 @@ var passwordlessTimeoutOption = new Option<int?>(
 
 passwordlessTimeoutOption.AddValidator( result => {
 	if( result.Tokens is [Token token, ..]
-		&& int.TryParse( token.Value, out int timeout ) ) {
-		if( timeout != 0
-			&& ( timeout < PasswordlessTimeoutDefaults.Min
-				|| timeout > PasswordlessTimeoutDefaults.Max ) ) {
-			result.ErrorMessage =
-				"Passwordless timeout must be 0 (disabled)"
-				+ $" or between {PasswordlessTimeoutDefaults.Min}"
-				+ $" and {PasswordlessTimeoutDefaults.Max} seconds";
-		}
-	} else if( result.Tokens.Count > 0 ) {
-		result.ErrorMessage =
-			"Passwordless timeout must be 0 (disabled)"
-			+ $" or between {PasswordlessTimeoutDefaults.Min}"
-			+ $" and {PasswordlessTimeoutDefaults.Max} seconds";
+		&& int.TryParse( token.Value, out int timeout )
+		&& timeout < 0 ) {
+		result.ErrorMessage
+			= "Passwordless timeout must be 0 (passwordless authentication disabled) or a positive number of seconds";
 	}
 } );
 

--- a/src/D2L.Bmx/Program.cs
+++ b/src/D2L.Bmx/Program.cs
@@ -18,10 +18,34 @@ var userOption = new Option<string>(
 	name: "--user",
 	description: ParameterDescriptions.User );
 
+var passwordlessTimeoutOption = new Option<int?>(
+	name: "--passwordless-timeout",
+	description: ParameterDescriptions.PasswordlessTimeout );
+
+passwordlessTimeoutOption.AddValidator( result => {
+	if( result.Tokens is [Token token, ..]
+		&& int.TryParse( token.Value, out int timeout ) ) {
+		if( timeout != 0
+			&& ( timeout < PasswordlessTimeoutDefaults.Min
+				|| timeout > PasswordlessTimeoutDefaults.Max ) ) {
+			result.ErrorMessage =
+				"Passwordless timeout must be 0 (disabled)"
+				+ $" or between {PasswordlessTimeoutDefaults.Min}"
+				+ $" and {PasswordlessTimeoutDefaults.Max} seconds";
+		}
+	} else if( result.Tokens.Count > 0 ) {
+		result.ErrorMessage =
+			"Passwordless timeout must be 0 (disabled)"
+			+ $" or between {PasswordlessTimeoutDefaults.Min}"
+			+ $" and {PasswordlessTimeoutDefaults.Max} seconds";
+	}
+} );
+
 // bmx login
 var loginCommand = new Command( "login", "Log into Okta and save an Okta session" ) {
 	orgOption,
 	userOption,
+	passwordlessTimeoutOption,
 };
 loginCommand.SetHandler( ( InvocationContext context ) => {
 	var messageWriter = new MessageWriter();
@@ -36,7 +60,8 @@ loginCommand.SetHandler( ( InvocationContext context ) => {
 	) );
 	return handler.HandleAsync(
 		org: context.ParseResult.GetValueForOption( orgOption ),
-		user: context.ParseResult.GetValueForOption( userOption )
+		user: context.ParseResult.GetValueForOption( userOption ),
+		passwordlessTimeout: context.ParseResult.GetValueForOption( passwordlessTimeoutOption )
 	);
 } );
 
@@ -64,6 +89,7 @@ var configureCommand = new Command( "configure", "Create or update the global BM
 	orgOption,
 	userOption,
 	durationOption,
+	passwordlessTimeoutOption,
 	nonInteractiveOption,
 };
 
@@ -75,6 +101,7 @@ configureCommand.SetHandler( ( InvocationContext context ) => {
 		org: context.ParseResult.GetValueForOption( orgOption ),
 		user: context.ParseResult.GetValueForOption( userOption ),
 		duration: context.ParseResult.GetValueForOption( durationOption ),
+		passwordlessTimeout: context.ParseResult.GetValueForOption( passwordlessTimeoutOption ),
 		nonInteractive: context.ParseResult.GetValueForOption( nonInteractiveOption )
 	);
 	return Task.CompletedTask;
@@ -120,6 +147,7 @@ var printCommand = new Command( "print", "Print AWS credentials" ) {
 	userOption,
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
+	passwordlessTimeoutOption,
 };
 
 printCommand.SetHandler( ( InvocationContext context ) => {
@@ -149,7 +177,8 @@ printCommand.SetHandler( ( InvocationContext context ) => {
 		duration: context.ParseResult.GetValueForOption( durationOption ),
 		nonInteractive: context.ParseResult.GetValueForOption( nonInteractiveOption ),
 		format: context.ParseResult.GetValueForOption( formatOption ),
-		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption )
+		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption ),
+		passwordlessTimeout: context.ParseResult.GetValueForOption( passwordlessTimeoutOption )
 	);
 } );
 
@@ -175,6 +204,7 @@ var writeCommand = new Command( "write", "Write AWS credentials to the credentia
 	nonInteractiveOption,
 	cacheAwsCredentialsOption,
 	useCredentialProcessOption,
+	passwordlessTimeoutOption,
 };
 
 writeCommand.SetHandler( ( InvocationContext context ) => {
@@ -210,7 +240,8 @@ writeCommand.SetHandler( ( InvocationContext context ) => {
 		output: context.ParseResult.GetValueForOption( outputOption ),
 		profile: context.ParseResult.GetValueForOption( profileOption ),
 		cacheAwsCredentials: context.ParseResult.GetValueForOption( cacheAwsCredentialsOption ),
-		useCredentialProcess: context.ParseResult.GetValueForOption( useCredentialProcessOption )
+		useCredentialProcess: context.ParseResult.GetValueForOption( useCredentialProcessOption ),
+		passwordlessTimeout: context.ParseResult.GetValueForOption( passwordlessTimeoutOption )
 	);
 } );
 

--- a/src/D2L.Bmx/WriteHandler.cs
+++ b/src/D2L.Bmx/WriteHandler.cs
@@ -27,7 +27,8 @@ internal class WriteHandler(
 		string? output,
 		string? profile,
 		bool cacheAwsCredentials,
-		bool useCredentialProcess
+		bool useCredentialProcess,
+		int? passwordlessTimeout
 	) {
 		cacheAwsCredentials = cacheAwsCredentials || useCredentialProcess;
 
@@ -35,7 +36,8 @@ internal class WriteHandler(
 			org: org,
 			user: user,
 			nonInteractive: nonInteractive,
-			ignoreCache: false
+			ignoreCache: false,
+			passwordlessTimeout: passwordlessTimeout
 		);
 		var awsCredsInfo = await awsCredsCreator.CreateAwsCredsAsync(
 			okta: oktaContext,


### PR DESCRIPTION
### Why

Zscaler can be slow for some people. Bump the default timeout from 15 to 30 seconds and add an optional config value to lower timeout or just disable passwordless entirely. Updating the tests in vulcan-scratch repo too to cover a few scenarios

### Ticket

[HOD-4334 - BMX: support longer timeouts](https://desire2learn.atlassian.net/browse/HOD-4334)
